### PR TITLE
move models to a separate package

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.17.x]
+        go-version: [1.18.x]
     name: golangci-lint
     runs-on: ${{ matrix.os }}
     steps:
@@ -25,4 +25,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44
+          version: v1.45

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.18.x]
+        go-version: [1.17.x]
     name: golangci-lint
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.18.x]
+        go-version: [1.17.x, 1.18.x]
     name: go-test
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.18.x]
     name: go-test
     runs-on: ${{ matrix.os }}
     steps:

--- a/rest/aggs/aggs.go
+++ b/rest/aggs/aggs.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/client"
+	"github.com/polygon-io/client-go/rest/models"
 )
 
 const (
@@ -21,29 +22,29 @@ type Client struct {
 
 // GetAggs retrieves aggregate bars for a specified ticker over a given date range in custom time window sizes.
 // For example, if timespan = ‘minute’ and multiplier = ‘5’ then 5-minute bars will be returned.
-func (ac *Client) GetAggs(ctx context.Context, params GetAggsParams, opts ...client.Option) (*AggsResponse, error) {
-	res := &AggsResponse{}
+func (ac *Client) GetAggs(ctx context.Context, params models.GetAggsParams, opts ...client.Option) (*models.AggsResponse, error) {
+	res := &models.AggsResponse{}
 	err := ac.Call(ctx, http.MethodGet, getAggsPath, params, res, opts...)
 	return res, err
 }
 
 // GetPreviousClose retrieves the previous day's open, high, low, and close (OHLC) for the specified ticker.
-func (ac *Client) GetPreviousClose(ctx context.Context, params GetPreviousCloseParams, opts ...client.Option) (*AggsResponse, error) {
-	res := &AggsResponse{}
+func (ac *Client) GetPreviousClose(ctx context.Context, params models.GetPreviousCloseParams, opts ...client.Option) (*models.AggsResponse, error) {
+	res := &models.AggsResponse{}
 	err := ac.Call(ctx, http.MethodGet, getPreviousClosePath, params, res, opts...)
 	return res, err
 }
 
 // GetGroupedDaily retrieves the daily open, high, low, and close (OHLC) for the specified market type.
-func (ac *Client) GetGroupedDaily(ctx context.Context, params GetGroupedDailyParams, opts ...client.Option) (*AggsResponse, error) {
-	res := &AggsResponse{}
+func (ac *Client) GetGroupedDaily(ctx context.Context, params models.GetGroupedDailyParams, opts ...client.Option) (*models.AggsResponse, error) {
+	res := &models.AggsResponse{}
 	err := ac.Call(ctx, http.MethodGet, getGroupedDailyPath, params, res, opts...)
 	return res, err
 }
 
 // GetDailyOpenClose retrieves the open, close and afterhours prices of a specific symbol on a certain date.
-func (ac *Client) GetDailyOpenClose(ctx context.Context, params GetDailyOpenCloseParams, opts ...client.Option) (*DailyOpenCloseResponse, error) {
-	res := &DailyOpenCloseResponse{}
+func (ac *Client) GetDailyOpenClose(ctx context.Context, params models.GetDailyOpenCloseParams, opts ...client.Option) (*models.DailyOpenCloseResponse, error) {
+	res := &models.DailyOpenCloseResponse{}
 	err := ac.Call(ctx, http.MethodGet, getDailyOpenClosePath, params, res, opts...)
 	return res, err
 }

--- a/rest/aggs/aggs_test.go
+++ b/rest/aggs/aggs_test.go
@@ -63,10 +63,10 @@ func TestGetAggs(t *testing.T) {
 		From:       time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC),
 		To:         time.Date(2021, 8, 22, 0, 0, 0, 0, time.UTC),
 		QueryParams: models.GetAggsQueryParams{
-			Adjusted: models.Ptr(true),
-			Order:    models.Ptr(models.Desc),
-			Limit:    models.Ptr(1),
-			Explain:  models.Ptr(false),
+			Adjusted: models.Bool(true),
+			Order:    models.SortOrder(models.Desc),
+			Limit:    models.Int(1),
+			Explain:  models.Bool(false),
 		},
 	})
 
@@ -93,7 +93,7 @@ func TestGetPreviousClose(t *testing.T) {
 	res, err := c.Aggs.GetPreviousClose(context.Background(), models.GetPreviousCloseParams{
 		Ticker: "AAPL",
 		QueryParams: models.GetPreviousCloseQueryParams{
-			Adjusted: models.Ptr(true),
+			Adjusted: models.Bool(true),
 		},
 	})
 
@@ -122,7 +122,7 @@ func TestGetGroupedDaily(t *testing.T) {
 		MarketType: models.Stocks,
 		Date:       time.Date(2021, 7, 22, 0, 0, 0, 0, time.Local),
 		QueryParams: models.GetGroupedDailyQueryParams{
-			Adjusted: models.Ptr(true),
+			Adjusted: models.Bool(true),
 		},
 	})
 
@@ -167,7 +167,7 @@ func TestGetDailyOpenClose(t *testing.T) {
 		Ticker: "AAPL",
 		Date:   time.Date(2020, 10, 14, 0, 0, 0, 0, time.Local),
 		QueryParams: models.GetDailyOpenCloseQueryParams{
-			Adjusted: models.Ptr(true),
+			Adjusted: models.Bool(true),
 		},
 	})
 

--- a/rest/aggs/aggs_test.go
+++ b/rest/aggs/aggs_test.go
@@ -64,7 +64,7 @@ func TestGetAggs(t *testing.T) {
 		To:         time.Date(2021, 8, 22, 0, 0, 0, 0, time.UTC),
 		QueryParams: models.GetAggsQueryParams{
 			Adjusted: models.Bool(true),
-			Order:    models.SortOrder(models.Desc),
+			Sort:     models.SortOrder(models.Desc),
 			Limit:    models.Int(1),
 			Explain:  models.Bool(false),
 		},

--- a/rest/aggs/aggs_test.go
+++ b/rest/aggs/aggs_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	polygon "github.com/polygon-io/client-go/rest"
-	"github.com/polygon-io/client-go/rest/aggs"
 	"github.com/polygon-io/client-go/rest/client"
+	"github.com/polygon-io/client-go/rest/models"
 	"github.com/stretchr/testify/assert"
 )
 
-var expectedResponse = aggs.AggsResponse{
+var expectedResponse = models.AggsResponse{
 	Ticker: "AAPL",
 	BaseResponse: client.BaseResponse{
 		Status:       "OK",
@@ -26,7 +26,7 @@ var expectedResponse = aggs.AggsResponse{
 	QueryCount:   1,
 	ResultsCount: 1,
 	Adjusted:     true,
-	Aggs: []aggs.Aggregate{
+	Aggs: []models.Aggregate{
 		{
 			Volume:       77287356,
 			VWAP:         146.991,
@@ -56,17 +56,17 @@ func TestGetAggs(t *testing.T) {
 		},
 	)
 
-	res, err := c.Aggs.GetAggs(context.Background(), aggs.GetAggsParams{
+	res, err := c.Aggs.GetAggs(context.Background(), models.GetAggsParams{
 		Ticker:     "AAPL",
 		Multiplier: 1,
 		Resolution: "day",
 		From:       time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC),
 		To:         time.Date(2021, 8, 22, 0, 0, 0, 0, time.UTC),
-		QueryParams: aggs.GetAggsQueryParams{
-			Adjusted: polygon.Bool(true),
-			Sort:     polygon.AggsSort(aggs.Desc),
-			Limit:    polygon.Int(1),
-			Explain:  polygon.Bool(false),
+		QueryParams: models.GetAggsQueryParams{
+			Adjusted: models.Ptr(true),
+			Order:    models.Ptr(models.Desc),
+			Limit:    models.Ptr(1),
+			Explain:  models.Ptr(false),
 		},
 	})
 
@@ -90,10 +90,10 @@ func TestGetPreviousClose(t *testing.T) {
 		},
 	)
 
-	res, err := c.Aggs.GetPreviousClose(context.Background(), aggs.GetPreviousCloseParams{
+	res, err := c.Aggs.GetPreviousClose(context.Background(), models.GetPreviousCloseParams{
 		Ticker: "AAPL",
-		QueryParams: aggs.GetPreviousCloseQueryParams{
-			Adjusted: polygon.Bool(true),
+		QueryParams: models.GetPreviousCloseQueryParams{
+			Adjusted: models.Ptr(true),
 		},
 	})
 
@@ -117,12 +117,12 @@ func TestGetGroupedDaily(t *testing.T) {
 		},
 	)
 
-	res, err := c.Aggs.GetGroupedDaily(context.Background(), aggs.GetGroupedDailyParams{
-		Locale:     aggs.US,
-		MarketType: aggs.Stocks,
+	res, err := c.Aggs.GetGroupedDaily(context.Background(), models.GetGroupedDailyParams{
+		Locale:     models.US,
+		MarketType: models.Stocks,
 		Date:       time.Date(2021, 7, 22, 0, 0, 0, 0, time.Local),
-		QueryParams: aggs.GetGroupedDailyQueryParams{
-			Adjusted: polygon.Bool(true),
+		QueryParams: models.GetGroupedDailyQueryParams{
+			Adjusted: models.Ptr(true),
 		},
 	})
 
@@ -140,7 +140,7 @@ func TestGetDailyOpenClose(t *testing.T) {
 		Status: "OK",
 	}
 
-	expectedResponse := aggs.DailyOpenCloseResponse{
+	expectedResponse := models.DailyOpenCloseResponse{
 		BaseResponse: expectedBaseResponse,
 		Symbol:       "AAPL",
 		From:         "2020-10-14",
@@ -163,11 +163,11 @@ func TestGetDailyOpenClose(t *testing.T) {
 		},
 	)
 
-	res, err := c.Aggs.GetDailyOpenClose(context.Background(), aggs.GetDailyOpenCloseParams{
+	res, err := c.Aggs.GetDailyOpenClose(context.Background(), models.GetDailyOpenCloseParams{
 		Ticker: "AAPL",
 		Date:   time.Date(2020, 10, 14, 0, 0, 0, 0, time.Local),
-		QueryParams: aggs.GetDailyOpenCloseQueryParams{
-			Adjusted: polygon.Bool(true),
+		QueryParams: models.GetDailyOpenCloseQueryParams{
+			Adjusted: models.Ptr(true),
 		},
 	})
 

--- a/rest/models/aggs.go
+++ b/rest/models/aggs.go
@@ -53,7 +53,7 @@ type GetAggsParams struct {
 
 // GetAggsQueryParams is the set of query parameters that can be used when requesting aggs through the Get method.
 type GetAggsQueryParams struct {
-	Order    *Order
+	Sort     *Order
 	Limit    *int
 	Adjusted *bool
 	Explain  *bool
@@ -74,8 +74,8 @@ func (p GetAggsParams) Path() map[string]string {
 func (p GetAggsParams) Query() map[string]string {
 	q := map[string]string{}
 
-	if p.QueryParams.Order != nil {
-		q["sort"] = string(*p.QueryParams.Order)
+	if p.QueryParams.Sort != nil {
+		q["sort"] = string(*p.QueryParams.Sort)
 	}
 
 	if p.QueryParams.Limit != nil {

--- a/rest/models/aggs.go
+++ b/rest/models/aggs.go
@@ -1,4 +1,4 @@
-package aggs
+package models
 
 import (
 	"fmt"
@@ -41,28 +41,6 @@ type AggsResponse struct {
 	Aggs         []Aggregate `json:"results,omitempty"`
 }
 
-// Sort the results by timestamp. asc will return results in ascending order (oldest at the top),
-// desc will return results in descending order (newest at the top).
-type Sort string
-
-const (
-	Asc  Sort = "asc"
-	Desc Sort = "desc"
-)
-
-// Resolution is the size of the time window.
-type Resolution string
-
-const (
-	Minute  Resolution = "minute"
-	Hour    Resolution = "hour"
-	Day     Resolution = "day"
-	Week    Resolution = "week"
-	Month   Resolution = "month"
-	Quarter Resolution = "quarter"
-	Year    Resolution = "year"
-)
-
 // GetAggsParams is the set of path and query parameters that can be used when requesting aggs through the Get method.
 type GetAggsParams struct {
 	Ticker      string
@@ -75,7 +53,7 @@ type GetAggsParams struct {
 
 // GetAggsQueryParams is the set of query parameters that can be used when requesting aggs through the Get method.
 type GetAggsQueryParams struct {
-	Sort     *Sort
+	Order    *Order
 	Limit    *int
 	Adjusted *bool
 	Explain  *bool
@@ -96,8 +74,8 @@ func (p GetAggsParams) Path() map[string]string {
 func (p GetAggsParams) Query() map[string]string {
 	q := map[string]string{}
 
-	if p.QueryParams.Sort != nil {
-		q["sort"] = string(*p.QueryParams.Sort)
+	if p.QueryParams.Order != nil {
+		q["sort"] = string(*p.QueryParams.Order)
 	}
 
 	if p.QueryParams.Limit != nil {
@@ -143,23 +121,6 @@ func (p GetPreviousCloseParams) Query() map[string]string {
 
 	return q
 }
-
-// Locale is the market location used to query aggs using the GetGroupedDaily method.
-type Locale string
-
-const (
-	US     Locale = "us"
-	Global Locale = "global"
-)
-
-// MarketType is the type of market used to query aggs using the GetGroupedDaily method.
-type MarketType string
-
-const (
-	Stocks MarketType = "stocks"
-	Forex  MarketType = "forex"
-	Crypto MarketType = "crypto"
-)
 
 // GetGroupedDailyParams is the set of path and query parameters that can be used when requesting aggs through the GetGroupedDaily method.
 type GetGroupedDailyParams struct {

--- a/rest/models/types.go
+++ b/rest/models/types.go
@@ -39,7 +39,17 @@ const (
 	Desc Order = "desc"
 )
 
-// Ptr returns a pointer to a specified value.
-func Ptr[T any](v T) *T {
+// Bool returns a pointer to a bool value.
+func Bool(v bool) *bool {
+	return &v
+}
+
+// Int returns a pointer to an int value.
+func Int(v int) *int {
+	return &v
+}
+
+// Order returns a pointer to a sort order value.
+func SortOrder(v Order) *Order {
 	return &v
 }

--- a/rest/models/types.go
+++ b/rest/models/types.go
@@ -1,0 +1,45 @@
+package models
+
+// MarketType is the type of market.
+type MarketType string
+
+const (
+	Stocks MarketType = "stocks"
+	Forex  MarketType = "forex"
+	Crypto MarketType = "crypto"
+)
+
+// Locale is the market location.
+type Locale string
+
+const (
+	US     Locale = "us"
+	Global Locale = "global"
+)
+
+// Resolution is the size of the time window.
+type Resolution string
+
+const (
+	Minute  Resolution = "minute"
+	Hour    Resolution = "hour"
+	Day     Resolution = "day"
+	Week    Resolution = "week"
+	Month   Resolution = "month"
+	Quarter Resolution = "quarter"
+	Year    Resolution = "year"
+)
+
+// Order the results. asc will return results in ascending order (oldest at the top),
+// desc will return results in descending order (newest at the top).
+type Order string
+
+const (
+	Asc  Order = "asc"
+	Desc Order = "desc"
+)
+
+// Ptr returns a pointer to a specified value.
+func Ptr[T any](v T) *T {
+	return &v
+}

--- a/rest/polygon.go
+++ b/rest/polygon.go
@@ -17,18 +17,3 @@ func New(apiKey string) *polygonClient {
 		Aggs: &aggs.Client{Client: c},
 	}
 }
-
-// Bool returns a pointer to a bool value.
-func Bool(v bool) *bool {
-	return &v
-}
-
-// Int returns a pointer to an int value.
-func Int(v int) *int {
-	return &v
-}
-
-// AggsSort returns a pointer to an aggs sort value.
-func AggsSort(v aggs.Sort) *aggs.Sort {
-	return &v
-}


### PR DESCRIPTION
Moving our models to a separate package. This makes more sense for eventual code generation and lets users just import two packages to use our client (`polygon` and `models`).