### PR TITLE
move iter to models

### DIFF
--- a/rest/models/iter.go
+++ b/rest/models/iter.go
@@ -1,14 +1,12 @@
-package client
+package models
 
 import (
 	"context"
-
-	"github.com/polygon-io/client-go/rest/models"
 )
 
 // Query defines a closure that domain specific iterators must implement. The implementation should
 // include a call to the API and should return the API response with a separate slice of the results.
-type Query func(string) (models.ListResponse, []interface{}, error)
+type Query func(string) (ListResponse, []interface{}, error)
 
 // Iter defines an iterator type that should be used when implementing list methods. It's intended to
 // be embedded in a domain specific iterator struct.
@@ -16,7 +14,7 @@ type Iter struct {
 	ctx   context.Context
 	query Query
 
-	page    models.ListResponse
+	page    ListResponse
 	item    interface{}
 	results []interface{}
 

--- a/rest/quotes/quotes.go
+++ b/rest/quotes/quotes.go
@@ -15,7 +15,7 @@ type Client struct {
 
 // ListQuotesIter is an iterator for the ListQuotes method.
 type ListQuotesIter struct {
-	client.Iter
+	models.Iter
 }
 
 // Quote returns the current result that the iterator points to.
@@ -48,7 +48,7 @@ func (c *Client) ListQuotes(ctx context.Context, params *models.ListQuotesParams
 	}
 
 	return &ListQuotesIter{
-		Iter: client.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
 			res := &models.ListQuotesResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/quotes/quotes.go
+++ b/rest/quotes/quotes.go
@@ -2,6 +2,7 @@ package quotes
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/client"
@@ -44,7 +45,7 @@ func (it *ListQuotesIter) Quote() models.Quote {
 func (c *Client) ListQuotes(ctx context.Context, params *models.ListQuotesParams, options ...models.RequestOption) (*ListQuotesIter, error) {
 	uri, err := c.EncodeParams(models.ListQuotesPath, params)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create iterator: %w", err)
 	}
 
 	return &ListQuotesIter{

--- a/rest/reference/conditions.go
+++ b/rest/reference/conditions.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/polygon-io/client-go/rest/client"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 // ListConditionsIter is an iterator for the ListConditions method.
 type ListConditionsIter struct {
-	client.Iter
+	models.Iter
 }
 
 // Condition returns the current result that the iterator points to.
@@ -43,7 +42,7 @@ func (c *Client) ListConditions(ctx context.Context, params *models.ListConditio
 	}
 
 	return &ListConditionsIter{
-		Iter: client.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
 			res := &models.ListConditionsResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/reference/conditions.go
+++ b/rest/reference/conditions.go
@@ -2,6 +2,7 @@ package reference
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/models"
@@ -38,7 +39,7 @@ func (it *ListConditionsIter) Condition() models.Condition {
 func (c *Client) ListConditions(ctx context.Context, params *models.ListConditionsParams, options ...models.RequestOption) (*ListConditionsIter, error) {
 	uri, err := c.EncodeParams(models.ListConditionsPath, params)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create iterator: %w", err)
 	}
 
 	return &ListConditionsIter{

--- a/rest/reference/dividends.go
+++ b/rest/reference/dividends.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/polygon-io/client-go/rest/client"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 // ListDividendsIter is an iterator for the ListDividends method.
 type ListDividendsIter struct {
-	client.Iter
+	models.Iter
 }
 
 // Dividend returns the current result that the iterator points to.
@@ -43,7 +42,7 @@ func (c *Client) ListDividends(ctx context.Context, params *models.ListDividends
 	}
 
 	return &ListDividendsIter{
-		Iter: client.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
 			res := &models.ListDividendsResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/reference/dividends.go
+++ b/rest/reference/dividends.go
@@ -2,6 +2,7 @@ package reference
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/models"
@@ -38,7 +39,7 @@ func (it *ListDividendsIter) Dividend() models.Dividend {
 func (c *Client) ListDividends(ctx context.Context, params *models.ListDividendsParams, options ...models.RequestOption) (*ListDividendsIter, error) {
 	uri, err := c.EncodeParams(models.ListDividendsPath, params)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create iterator: %w", err)
 	}
 
 	return &ListDividendsIter{

--- a/rest/reference/splits.go
+++ b/rest/reference/splits.go
@@ -2,6 +2,7 @@ package reference
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/models"
@@ -38,7 +39,7 @@ func (it *ListSplitsIter) Split() models.Split {
 func (c *Client) ListSplits(ctx context.Context, params *models.ListSplitsParams, options ...models.RequestOption) (*ListSplitsIter, error) {
 	uri, err := c.EncodeParams(models.ListSplitsPath, params)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create iterator: %w", err)
 	}
 
 	return &ListSplitsIter{

--- a/rest/reference/splits.go
+++ b/rest/reference/splits.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/polygon-io/client-go/rest/client"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 // ListSplitsIter is an iterator for the ListSplits method.
 type ListSplitsIter struct {
-	client.Iter
+	models.Iter
 }
 
 // Split returns the current result that the iterator points to.
@@ -43,7 +42,7 @@ func (c *Client) ListSplits(ctx context.Context, params *models.ListSplitsParams
 	}
 
 	return &ListSplitsIter{
-		Iter: client.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
 			res := &models.ListSplitsResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/reference/tickers.go
+++ b/rest/reference/tickers.go
@@ -2,6 +2,7 @@ package reference
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/models"
@@ -38,7 +39,7 @@ func (it *ListTickersIter) Ticker() models.Ticker {
 func (c *Client) ListTickers(ctx context.Context, params *models.ListTickersParams, options ...models.RequestOption) (*ListTickersIter, error) {
 	uri, err := c.EncodeParams(models.ListTickersPath, params)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create iterator: %w", err)
 	}
 
 	return &ListTickersIter{

--- a/rest/reference/tickers.go
+++ b/rest/reference/tickers.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/polygon-io/client-go/rest/client"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 // ListTickersIter is an iterator for the ListTickers method.
 type ListTickersIter struct {
-	client.Iter
+	models.Iter
 }
 
 // Ticker returns the current result that the iterator points to.
@@ -43,7 +42,7 @@ func (c *Client) ListTickers(ctx context.Context, params *models.ListTickersPara
 	}
 
 	return &ListTickersIter{
-		Iter: client.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
 			res := &models.ListTickersResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/trades/trades.go
+++ b/rest/trades/trades.go
@@ -2,6 +2,7 @@ package trades
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/client"
@@ -44,7 +45,7 @@ func (it *ListTradesIter) Trade() models.Trade {
 func (c *Client) ListTrades(ctx context.Context, params *models.ListTradesParams, options ...models.RequestOption) (*ListTradesIter, error) {
 	uri, err := c.EncodeParams(models.ListTradesPath, params)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create iterator: %w", err)
 	}
 
 	return &ListTradesIter{

--- a/rest/trades/trades.go
+++ b/rest/trades/trades.go
@@ -15,7 +15,7 @@ type Client struct {
 
 // ListTradesIter is an iterator for the ListTickers method.
 type ListTradesIter struct {
-	client.Iter
+	models.Iter
 }
 
 // Trade returns the current result that the iterator points to.
@@ -48,7 +48,7 @@ func (c *Client) ListTrades(ctx context.Context, params *models.ListTradesParams
 	}
 
 	return &ListTradesIter{
-		Iter: client.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
 			res := &models.ListTradesResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 


### PR DESCRIPTION
proposing we move this type to the models package since it acts as a response type for list methods