### PR TITLE
change iter method interface

### DIFF
--- a/rest/models/iter.go
+++ b/rest/models/iter.go
@@ -42,7 +42,7 @@ func NewIterErr(ctx context.Context, err error) Iter {
 
 // Next moves the iterator to the next result.
 func (it *Iter) Next() bool {
-	if it.err != nil || it.ctx.Err() != nil {
+	if it.err != nil {
 		return false
 	}
 

--- a/rest/models/iter.go
+++ b/rest/models/iter.go
@@ -32,8 +32,20 @@ func NewIter(ctx context.Context, uri string, query Query) Iter {
 	return it
 }
 
+// NewIterErr returns an iterator with an error describing why it failed to create.
+func NewIterErr(ctx context.Context, err error) Iter {
+	return Iter{
+		ctx: ctx,
+		err: err,
+	}
+}
+
 // Next moves the iterator to the next result.
 func (it *Iter) Next() bool {
+	if it.err != nil || it.ctx.Err() != nil {
+		return false
+	}
+
 	if len(it.results) == 0 && it.page.NextPageURL() != "" {
 		it.page, it.results, it.err = it.query(it.page.NextPageURL())
 	}

--- a/rest/models/iter_test.go
+++ b/rest/models/iter_test.go
@@ -3,7 +3,6 @@ package models_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -48,10 +47,10 @@ type ListResourceParams struct {
 	Timestamp *string `query:"timestamp"`
 }
 
-func (c *Client) ListResource(ctx context.Context, params ListResourceParams, options ...models.RequestOption) (*ListResourceIter, error) {
+func (c *Client) ListResource(ctx context.Context, params ListResourceParams, options ...models.RequestOption) *ListResourceIter {
 	uri, err := c.EncodeParams(listResourcePath, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create iterator: %w", err)
+		return &ListResourceIter{Iter: models.NewIterErr(ctx, err)}
 	}
 
 	return &ListResourceIter{
@@ -66,7 +65,7 @@ func (c *Client) ListResource(ctx context.Context, params ListResourceParams, op
 
 			return res, results, err
 		}),
-	}, nil
+	}
 }
 
 func TestListResource(t *testing.T) {
@@ -113,12 +112,11 @@ func TestListResource(t *testing.T) {
 		},
 	})
 
-	iter, err := c.ListResource(context.Background(), ListResourceParams{
+	iter := c.ListResource(context.Background(), ListResourceParams{
 		Ticker: "ticker1",
 	})
 
 	// verify the first page
-	assert.Nil(t, err)
 	assert.Nil(t, iter.Err())
 	assert.NotNil(t, iter.Resource())
 	// verify the first and second quotes
@@ -158,12 +156,12 @@ func TestListResourceError(t *testing.T) {
 		BaseResponse: baseRes,
 	})
 
-	iter, err := c.ListResource(context.Background(), ListResourceParams{
+	iter := c.ListResource(context.Background(), ListResourceParams{
 		Ticker: "ticker1",
 	})
 
 	// iter.Next() should return false and the error should not be nil
-	assert.Nil(t, err)
+	assert.NotNil(t, iter.Err())
 	assert.False(t, iter.Next())
 	assert.NotNil(t, iter.Err())
 	assert.Equal(t, expectedErr.Error(), iter.Err().Error())

--- a/rest/quotes/quotes.go
+++ b/rest/quotes/quotes.go
@@ -2,7 +2,6 @@ package quotes
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/client"
@@ -31,10 +30,6 @@ func (it *ListQuotesIter) Quote() models.Quote {
 // For more details see https://polygon.io/docs/stocks/get_v3_quotes__stockticker.
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListQuotes(context.TODO(), params, opts...)
-//   if err != nil {
-//       return err
-//   }
-//
 //   for iter.Next() {
 //       // do something with the current value
 //       log.Print(iter.Quote())
@@ -42,10 +37,10 @@ func (it *ListQuotesIter) Quote() models.Quote {
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *Client) ListQuotes(ctx context.Context, params *models.ListQuotesParams, options ...models.RequestOption) (*ListQuotesIter, error) {
+func (c *Client) ListQuotes(ctx context.Context, params *models.ListQuotesParams, options ...models.RequestOption) *ListQuotesIter {
 	uri, err := c.EncodeParams(models.ListQuotesPath, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create iterator: %w", err)
+		return &ListQuotesIter{Iter: models.NewIterErr(ctx, err)}
 	}
 
 	return &ListQuotesIter{
@@ -60,7 +55,7 @@ func (c *Client) ListQuotes(ctx context.Context, params *models.ListQuotesParams
 
 			return res, results, err
 		}),
-	}, nil
+	}
 }
 
 // GetLastQuote retrieves the last quote (NBBO) for a specified ticker.

--- a/rest/quotes/quotes_test.go
+++ b/rest/quotes/quotes_test.go
@@ -64,12 +64,11 @@ func TestListQuotes(t *testing.T) {
 
 	registerResponder("https://api.polygon.io/v3/quotes/AAPL?limit=2&order=asc&sort=timestamp&timestamp=1626912000000000000", expectedResponse)
 	registerResponder("https://api.polygon.io/v3/quotes/AAPL?cursor=YWN0aXZlPXRydWUmZGF0ZT0yMDIxLTA0LTI1JmxpbWl0PTEmb3JkZXI9YXNjJnBhZ2VfbWFya2VyPUElN0M5YWRjMjY0ZTgyM2E1ZjBiOGUyNDc5YmZiOGE1YmYwNDVkYzU0YjgwMDcyMWE2YmI1ZjBjMjQwMjU4MjFmNGZiJnNvcnQ9dGlja2Vy", "{}")
-	iter, err := c.Quotes.ListQuotes(context.Background(), models.ListQuotesParams{Ticker: "AAPL"}.
+	iter := c.Quotes.ListQuotes(context.Background(), models.ListQuotesParams{Ticker: "AAPL"}.
 		WithTimestamp(models.EQ, models.Nanos(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))).
 		WithSort(models.Timestamp).WithOrder(models.Asc).WithLimit(2))
 
 	// iter creation
-	assert.Nil(t, err)
 	assert.Nil(t, iter.Err())
 	assert.NotNil(t, iter.Quote())
 

--- a/rest/reference/conditions.go
+++ b/rest/reference/conditions.go
@@ -2,7 +2,6 @@ package reference
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/models"
@@ -25,10 +24,6 @@ func (it *ListConditionsIter) Condition() models.Condition {
 // For more details see https://polygon.io/docs/stocks/get_v3_reference_conditions.
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListConditions(context.TODO(), params, opts...)
-//   if err != nil {
-//       return err
-//   }
-//
 //   for iter.Next() {
 //       // do something with the current value
 //       log.Print(iter.Condition())
@@ -36,10 +31,10 @@ func (it *ListConditionsIter) Condition() models.Condition {
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *Client) ListConditions(ctx context.Context, params *models.ListConditionsParams, options ...models.RequestOption) (*ListConditionsIter, error) {
+func (c *Client) ListConditions(ctx context.Context, params *models.ListConditionsParams, options ...models.RequestOption) *ListConditionsIter {
 	uri, err := c.EncodeParams(models.ListConditionsPath, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create iterator: %w", err)
+		return &ListConditionsIter{Iter: models.NewIterErr(ctx, err)}
 	}
 
 	return &ListConditionsIter{
@@ -54,5 +49,5 @@ func (c *Client) ListConditions(ctx context.Context, params *models.ListConditio
 
 			return res, results, err
 		}),
-	}, nil
+	}
 }

--- a/rest/reference/conditions_test.go
+++ b/rest/reference/conditions_test.go
@@ -55,10 +55,9 @@ func TestListConditions(t *testing.T) {
 
 	registerResponder("https://api.polygon.io/v3/reference/conditions?asset_class=stocks&data_type=trade&limit=1", expectedResponse)
 	registerResponder("https://api.polygon.io/v3/reference/conditions?cursor=YXA9MiZhcz0mYXNzZXRfY2xhc3M9c3RvY2tzJmRhdGFfdHlwZT10cmFkZSZsaW1pdD0yJnNvcnQ9YXNzZXRfY2xhc3M", "{}")
-	iter, err := c.Reference.ListConditions(context.Background(), models.ListConditionsParams{}.WithAssetClass(models.AssetStocks).WithDataType(models.DataTrade).WithLimit(1))
+	iter := c.Reference.ListConditions(context.Background(), models.ListConditionsParams{}.WithAssetClass(models.AssetStocks).WithDataType(models.DataTrade).WithLimit(1))
 
 	// iter creation
-	assert.Nil(t, err)
 	assert.Nil(t, iter.Err())
 	assert.NotNil(t, iter.Condition())
 

--- a/rest/reference/dividends.go
+++ b/rest/reference/dividends.go
@@ -2,7 +2,6 @@ package reference
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/models"
@@ -25,10 +24,6 @@ func (it *ListDividendsIter) Dividend() models.Dividend {
 // For more details see https://polygon.io/docs/stocks/get_v3_reference_dividends.
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListDividends(context.TODO(), params, opts...)
-//   if err != nil {
-//       return err
-//   }
-//
 //   for iter.Next() {
 //       // do something with the current value
 //       log.Print(iter.Dividend())
@@ -36,10 +31,10 @@ func (it *ListDividendsIter) Dividend() models.Dividend {
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *Client) ListDividends(ctx context.Context, params *models.ListDividendsParams, options ...models.RequestOption) (*ListDividendsIter, error) {
+func (c *Client) ListDividends(ctx context.Context, params *models.ListDividendsParams, options ...models.RequestOption) *ListDividendsIter {
 	uri, err := c.EncodeParams(models.ListDividendsPath, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create iterator: %w", err)
+		return &ListDividendsIter{Iter: models.NewIterErr(ctx, err)}
 	}
 
 	return &ListDividendsIter{
@@ -54,5 +49,5 @@ func (c *Client) ListDividends(ctx context.Context, params *models.ListDividends
 
 			return res, results, err
 		}),
-	}, nil
+	}
 }

--- a/rest/reference/dividends_test.go
+++ b/rest/reference/dividends_test.go
@@ -39,10 +39,9 @@ func TestListDividends(t *testing.T) {
 
 	registerResponder("https://api.polygon.io/v3/reference/dividends?dividend_type=CD&ticker=CSSEN", expectedResponse)
 	registerResponder("https://api.polygon.io/v3/reference/dividends?cursor=YXA9MjUmYXM9JmxpbWl0PTEwJm9yZGVyPWRlc2Mmc29ydD1leF9kaXZpZGVuZF9kYXRlJnRpY2tlcj1DU1NFTg", "{}")
-	iter, err := c.Reference.ListDividends(context.Background(), models.ListDividendsParams{}.WithTicker(models.EQ, "CSSEN").WithDividendType(models.DividendCD))
+	iter := c.Reference.ListDividends(context.Background(), models.ListDividendsParams{}.WithTicker(models.EQ, "CSSEN").WithDividendType(models.DividendCD))
 
 	// iter creation
-	assert.Nil(t, err)
 	assert.Nil(t, iter.Err())
 	assert.NotNil(t, iter.Dividend())
 

--- a/rest/reference/splits.go
+++ b/rest/reference/splits.go
@@ -2,7 +2,6 @@ package reference
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/models"
@@ -25,10 +24,6 @@ func (it *ListSplitsIter) Split() models.Split {
 // For more details see https://polygon.io/docs/stocks/get_v3_reference_splits.
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListSplits(context.TODO(), params, opts...)
-//   if err != nil {
-//       return err
-//   }
-//
 //   for iter.Next() {
 //       // do something with the current value
 //       log.Print(iter.Split())
@@ -36,10 +31,10 @@ func (it *ListSplitsIter) Split() models.Split {
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *Client) ListSplits(ctx context.Context, params *models.ListSplitsParams, options ...models.RequestOption) (*ListSplitsIter, error) {
+func (c *Client) ListSplits(ctx context.Context, params *models.ListSplitsParams, options ...models.RequestOption) *ListSplitsIter {
 	uri, err := c.EncodeParams(models.ListSplitsPath, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create iterator: %w", err)
+		return &ListSplitsIter{Iter: models.NewIterErr(ctx, err)}
 	}
 
 	return &ListSplitsIter{
@@ -54,5 +49,5 @@ func (c *Client) ListSplits(ctx context.Context, params *models.ListSplitsParams
 
 			return res, results, err
 		}),
-	}, nil
+	}
 }

--- a/rest/reference/splits_test.go
+++ b/rest/reference/splits_test.go
@@ -34,12 +34,11 @@ func TestListSplits(t *testing.T) {
 }`
 
 	registerResponder("https://api.polygon.io/v3/reference/splits?execution_date=2021-07-22&limit=2&order=asc&reverse_split=false&sort=ticker&ticker=AAPL", expectedResponse)
-	iter, err := c.Reference.ListSplits(context.Background(), models.ListSplitsParams{}.
+	iter := c.Reference.ListSplits(context.Background(), models.ListSplitsParams{}.
 		WithTicker(models.EQ, "AAPL").WithExecutionDate(models.EQ, models.Date(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))).WithReverseSplit(false).
 		WithSort(models.TickerSymbol).WithOrder(models.Asc).WithLimit(2))
 
 	// iter creation
-	assert.Nil(t, err)
 	assert.Nil(t, iter.Err())
 	assert.NotNil(t, iter.Split())
 

--- a/rest/reference/tickers.go
+++ b/rest/reference/tickers.go
@@ -2,7 +2,6 @@ package reference
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/models"
@@ -25,10 +24,6 @@ func (it *ListTickersIter) Ticker() models.Ticker {
 // For more details see https://polygon.io/docs/stocks/get_v3_reference_tickers__ticker.
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListTickers(context.TODO(), params, opts...)
-//   if err != nil {
-//       return err
-//   }
-//
 //   for iter.Next() {
 //       // do something with the current value
 //       log.Print(iter.Ticker())
@@ -36,10 +31,10 @@ func (it *ListTickersIter) Ticker() models.Ticker {
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *Client) ListTickers(ctx context.Context, params *models.ListTickersParams, options ...models.RequestOption) (*ListTickersIter, error) {
+func (c *Client) ListTickers(ctx context.Context, params *models.ListTickersParams, options ...models.RequestOption) *ListTickersIter {
 	uri, err := c.EncodeParams(models.ListTickersPath, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create iterator: %w", err)
+		return &ListTickersIter{Iter: models.NewIterErr(ctx, err)}
 	}
 
 	return &ListTickersIter{
@@ -54,7 +49,7 @@ func (c *Client) ListTickers(ctx context.Context, params *models.ListTickersPara
 
 			return res, results, err
 		}),
-	}, nil
+	}
 }
 
 // GetTickerDetails retrieves details for a specified ticker.

--- a/rest/reference/tickers_test.go
+++ b/rest/reference/tickers_test.go
@@ -47,14 +47,13 @@ func TestListTickers(t *testing.T) {
 
 	registerResponder("https://api.polygon.io/v3/reference/tickers?active=true&cik=5&cusip=10&date=2021-07-22&exchange=4&limit=2&market=stocks&order=asc&sort=ticker&type=CS", expectedResponse)
 	registerResponder("https://api.polygon.io/v3/reference/tickers?cursor=YWN0aXZlPXRydWUmZGF0ZT0yMDIxLTA0LTI1JmxpbWl0PTEmb3JkZXI9YXNjJnBhZ2VfbWFya2VyPUElN0M5YWRjMjY0ZTgyM2E1ZjBiOGUyNDc5YmZiOGE1YmYwNDVkYzU0YjgwMDcyMWE2YmI1ZjBjMjQwMjU4MjFmNGZiJnNvcnQ9dGlja2Vy", "{}")
-	iter, err := c.Reference.ListTickers(context.Background(), models.ListTickersParams{}.
+	iter := c.Reference.ListTickers(context.Background(), models.ListTickersParams{}.
 		WithType("CS").WithMarket(models.AssetStocks).
 		WithExchange(4).WithCUSIP(10).WithCIK(5).
 		WithDate(models.Date(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))).WithActive(true).
 		WithSort(models.TickerSymbol).WithOrder(models.Asc).WithLimit(2))
 
 	// iter creation
-	assert.Nil(t, err)
 	assert.Nil(t, iter.Err())
 	assert.NotNil(t, iter.Ticker())
 

--- a/rest/trades/trades.go
+++ b/rest/trades/trades.go
@@ -2,7 +2,6 @@ package trades
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/client"
@@ -31,10 +30,6 @@ func (it *ListTradesIter) Trade() models.Trade {
 // For more details see https://polygon.io/docs/stocks/get_v3_trades__stockticker.
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListTrades(context.TODO(), params, opts...)
-//   if err != nil {
-//       return err
-//   }
-//
 //   for iter.Next() {
 //       // do something with the current value
 //       log.Print(iter.Trade())
@@ -42,10 +37,10 @@ func (it *ListTradesIter) Trade() models.Trade {
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *Client) ListTrades(ctx context.Context, params *models.ListTradesParams, options ...models.RequestOption) (*ListTradesIter, error) {
+func (c *Client) ListTrades(ctx context.Context, params *models.ListTradesParams, options ...models.RequestOption) *ListTradesIter {
 	uri, err := c.EncodeParams(models.ListTradesPath, params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create iterator: %w", err)
+		return &ListTradesIter{Iter: models.NewIterErr(ctx, err)}
 	}
 
 	return &ListTradesIter{
@@ -60,7 +55,7 @@ func (c *Client) ListTrades(ctx context.Context, params *models.ListTradesParams
 
 			return res, results, err
 		}),
-	}, nil
+	}
 }
 
 // GetLastTrade retrieves the last trade for a specified ticker.

--- a/rest/trades/trades_test.go
+++ b/rest/trades/trades_test.go
@@ -62,12 +62,11 @@ func TestListTrades(t *testing.T) {
 
 	registerResponder("https://api.polygon.io/v3/trades/AAPL?limit=2&order=asc&sort=timestamp&timestamp.gte=1626912000000000000", expectedResponse)
 	registerResponder("https://api.polygon.io/v3/trades/AAPL?cursor=YWN0aXZlPXRydWUmZGF0ZT0yMDIxLTA0LTI1JmxpbWl0PTEmb3JkZXI9YXNjJnBhZ2VfbWFya2VyPUElN0M5YWRjMjY0ZTgyM2E1ZjBiOGUyNDc5YmZiOGE1YmYwNDVkYzU0YjgwMDcyMWE2YmI1ZjBjMjQwMjU4MjFmNGZiJnNvcnQ9dGlja2Vy&sort=timestamp", "{}")
-	iter, err := c.Trades.ListTrades(context.Background(), models.ListTradesParams{Ticker: "AAPL"}.
+	iter := c.Trades.ListTrades(context.Background(), models.ListTradesParams{Ticker: "AAPL"}.
 		WithTimestamp(models.GTE, models.Nanos(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))).
 		WithOrder(models.Asc).WithLimit(2), models.QueryParam("sort", string(models.Timestamp)))
 
 	// iter creation
-	assert.Nil(t, err)
 	assert.Nil(t, iter.Err())
 	assert.NotNil(t, iter.Trade())
 


### PR DESCRIPTION
i think this is worth changing after a bit more thought. i don't want there to be confusion on the difference between err and iter.Err()