### PR TITLE
reorganize iter and encoder types

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ After creating the client, making calls to the Polygon API is simple.
 
 ```golang
 params := models.GetAllTickersSnapshotParams{
-    Locale:     "us",
-    MarketType: "stocks",
+    Locale:     models.US,
+    MarketType: models.Stocks,
 }.WithTickers("AAPL,MSFT")
 
 res, err := c.Snapshot.GetAllTickersSnapshot(context.Background(), params)
@@ -57,10 +57,6 @@ params := models.ListTradesParams{Ticker: "AAPL"}.
     WithOrder(models.Asc)
 
 iter, err := c.Trades.ListTrades(context.Background(), params)
-if err != nil {
-    log.Fatal(err)
-}
-
 for iter.Next() { // iter.Next() advances the iterator to the next value in the list
     log.Print(iter.Trade()) // do something with the current value
 }

--- a/rest/encoder/encoder.go
+++ b/rest/encoder/encoder.go
@@ -1,0 +1,103 @@
+package encoder
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-playground/form/v4"
+	"github.com/go-playground/validator/v10"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+// Encoder defines a path and query param encoder that plays nicely with the Polygon REST API.
+type Encoder struct {
+	validate     *validator.Validate
+	pathEncoder  *form.Encoder
+	queryEncoder *form.Encoder
+}
+
+// New returns a new path and query param encoder.
+func New() *Encoder {
+	return &Encoder{
+		validate:     validator.New(),
+		pathEncoder:  newEncoder("path"),
+		queryEncoder: newEncoder("query"),
+	}
+}
+
+// EncodeParams encodes path and query params and returns a valid request URI.
+func (e *Encoder) EncodeParams(path string, params interface{}) (string, error) {
+	if err := e.validateParams(params); err != nil {
+		return "", err
+	}
+
+	uri, err := e.encodePath(path, params)
+	if err != nil {
+		return "", err
+	}
+
+	query, err := e.encodeQuery(params)
+	if err != nil {
+		return "", err
+	} else if query != "" {
+		uri += "?" + query
+	}
+
+	return uri, nil
+}
+
+func (e *Encoder) validateParams(params interface{}) error {
+	if err := e.validate.Struct(params); err != nil {
+		return fmt.Errorf("invalid request params: %w", err)
+	}
+	return nil
+}
+
+func (e *Encoder) encodePath(uri string, params interface{}) (string, error) {
+	val, err := e.pathEncoder.Encode(&params)
+	if err != nil {
+		return "", fmt.Errorf("error encoding path params: %w", err)
+	}
+
+	pathParams := map[string]string{}
+	for k, v := range val {
+		pathParams[k] = v[0] // only accept the first one for a given key
+	}
+
+	for k, v := range pathParams {
+		uri = strings.ReplaceAll(uri, fmt.Sprintf("{%s}", k), url.PathEscape(v))
+	}
+
+	return uri, nil
+}
+
+func (e *Encoder) encodeQuery(params interface{}) (string, error) {
+	query, err := e.queryEncoder.Encode(&params)
+	if err != nil {
+		return "", fmt.Errorf("error encoding query params: %w", err)
+	}
+	return query.Encode(), nil
+}
+
+func newEncoder(tag string) *form.Encoder {
+	e := form.NewEncoder()
+	e.SetMode(form.ModeExplicit)
+	e.SetTagName(tag)
+
+	e.RegisterCustomTypeFunc(func(x interface{}) ([]string, error) {
+		return []string{fmt.Sprint(time.Time(x.(models.Time)).Format("2006-01-02T15:04:05.000Z"))}, nil
+	}, models.Time{})
+	e.RegisterCustomTypeFunc(func(x interface{}) ([]string, error) {
+		return []string{fmt.Sprint(time.Time(x.(models.Date)).Format("2006-01-02"))}, nil
+	}, models.Date{})
+	e.RegisterCustomTypeFunc(func(x interface{}) ([]string, error) {
+		return []string{fmt.Sprint(time.Time(x.(models.Millis)).UnixMilli())}, nil
+	}, models.Millis{})
+	e.RegisterCustomTypeFunc(func(x interface{}) ([]string, error) {
+		return []string{fmt.Sprint(time.Time(x.(models.Nanos)).UnixNano())}, nil
+	}, models.Nanos{})
+
+	return e
+}

--- a/rest/encoder/encoder_test.go
+++ b/rest/encoder/encoder_test.go
@@ -1,0 +1,121 @@
+package encoder_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/encoder"
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeParams(t *testing.T) {
+	testPath := "/v1/{num}/{str}"
+
+	type Params struct {
+		Num float64 `validate:"required" path:"num"`
+		Str string  `validate:"required" path:"str"`
+
+		NumQ *float64 `query:"num"`
+		StrQ *string  `query:"str"`
+	}
+
+	num := 1.6302
+	str := "testing"
+	params := Params{
+		Num:  1.6302,
+		Str:  str,
+		NumQ: &num,
+		StrQ: &str,
+	}
+
+	expected := "/v1/1.6302/testing?num=1.6302&str=testing"
+	actual, err := encoder.New().EncodeParams(testPath, params)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestEncodeTime(t *testing.T) {
+	testPath := "/v1/{time}"
+
+	type Params struct {
+		Time  models.Time  `validate:"required" path:"time"`
+		TimeQ *models.Time `query:"time"`
+	}
+
+	ptime := models.Time(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))
+	params := Params{
+		Time:  ptime,
+		TimeQ: &ptime,
+	}
+
+	expected := "/v1/2021-07-22T00:00:00.000Z?time=2021-07-22T00%3A00%3A00.000Z"
+	actual, err := encoder.New().EncodeParams(testPath, params)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestEncodeDate(t *testing.T) {
+	testPath := "/v1/{date}"
+
+	type Params struct {
+		Date  models.Date  `validate:"required" path:"date"`
+		DateQ *models.Date `query:"date"`
+	}
+
+	pdate := models.Date(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))
+	params := Params{
+		Date:  pdate,
+		DateQ: &pdate,
+	}
+
+	expected := "/v1/2021-07-22?date=2021-07-22"
+	actual, err := encoder.New().EncodeParams(testPath, params)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestEncodeMillis(t *testing.T) {
+	testPath := "/v1/{millis}"
+
+	type Params struct {
+		Millis  models.Millis  `validate:"required" path:"millis"`
+		MillisQ *models.Millis `query:"millis"`
+	}
+
+	pmillis := models.Millis(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))
+	params := Params{
+		Millis:  pmillis,
+		MillisQ: &pmillis,
+	}
+
+	expected := "/v1/1626912000000?millis=1626912000000"
+	actual, err := encoder.New().EncodeParams(testPath, params)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestEncodeNanos(t *testing.T) {
+	testPath := "/v1/{nanos}"
+
+	type Params struct {
+		Nanos  models.Nanos  `validate:"required" path:"nanos"`
+		NanosQ *models.Nanos `query:"nanos"`
+	}
+
+	pnanos := models.Nanos(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))
+	params := Params{
+		Nanos:  pnanos,
+		NanosQ: &pnanos,
+	}
+
+	expected := "/v1/1626912000000000000?nanos=1626912000000000000"
+	actual, err := encoder.New().EncodeParams(testPath, params)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestValidateError(t *testing.T) {
+	_, err := encoder.New().EncodeParams("/v1/test", nil)
+	assert.NotNil(t, err)
+}

--- a/rest/iter/iter.go
+++ b/rest/iter/iter.go
@@ -1,15 +1,23 @@
-package models
+package iter
 
 import (
 	"context"
+
+	"github.com/polygon-io/client-go/rest/encoder"
 )
+
+// ListResponse defines an interface that list API responses must implement.
+type ListResponse interface {
+	// NextPage returns a URL for retrieving the next page of list results.
+	NextPage() string
+}
 
 // Query defines a closure that domain specific iterators must implement. The implementation should
 // include a call to the API and should return the API response with a separate slice of the results.
 type Query func(string) (ListResponse, []interface{}, error)
 
-// Iter defines an iterator type that should be used when implementing list methods. It's intended to
-// be embedded in a domain specific iterator struct.
+// Iter defines an iterator type that is returned by list methods. It's intended to be embedded in a
+// domain specific iterator struct.
 type Iter struct {
 	ctx   context.Context
 	query Query
@@ -23,21 +31,20 @@ type Iter struct {
 
 // NewIter returns a new initialized iterator. This method automatically makes the first query to populate
 // the results. List methods should use this helper method when building domain specific iterators.
-func NewIter(ctx context.Context, uri string, query Query) Iter {
+func NewIter(ctx context.Context, path string, params interface{}, query Query) Iter {
 	it := Iter{
 		ctx:   ctx,
 		query: query,
 	}
+
+	uri, err := encoder.New().EncodeParams(path, params)
+	if err != nil {
+		it.err = err
+		return it
+	}
+
 	it.page, it.results, it.err = it.query(uri)
 	return it
-}
-
-// NewIterErr returns an iterator with an error describing why it failed to create.
-func NewIterErr(ctx context.Context, err error) Iter {
-	return Iter{
-		ctx: ctx,
-		err: err,
-	}
 }
 
 // Next moves the iterator to the next result.
@@ -46,8 +53,8 @@ func (it *Iter) Next() bool {
 		return false
 	}
 
-	if len(it.results) == 0 && it.page.NextPageURL() != "" {
-		it.page, it.results, it.err = it.query(it.page.NextPageURL())
+	if len(it.results) == 0 && it.page.NextPage() != "" {
+		it.page, it.results, it.err = it.query(it.page.NextPage())
 	}
 
 	if it.err != nil || len(it.results) == 0 {

--- a/rest/iter/iter_test.go
+++ b/rest/iter/iter_test.go
@@ -1,4 +1,4 @@
-package models_test
+package iter_test
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/polygon-io/client-go/rest/client"
+	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
@@ -22,7 +23,7 @@ type Client struct {
 }
 
 type ListResourceIter struct {
-	models.Iter
+	iter.Iter
 }
 
 func (it *ListResourceIter) Resource() Resource {
@@ -48,13 +49,8 @@ type ListResourceParams struct {
 }
 
 func (c *Client) ListResource(ctx context.Context, params *ListResourceParams, options ...models.RequestOption) *ListResourceIter {
-	uri, err := c.EncodeParams(listResourcePath, params)
-	if err != nil {
-		return &ListResourceIter{Iter: models.NewIterErr(ctx, err)}
-	}
-
 	return &ListResourceIter{
-		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: iter.NewIter(ctx, listResourcePath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
 			res := &ListResourceResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/models/response.go
+++ b/rest/models/response.go
@@ -2,12 +2,6 @@ package models
 
 import "fmt"
 
-// ListResponse defines an interface that list API responses must implement.
-type ListResponse interface {
-	// NextPageURL returns a URL for retrieving the next page of list results.
-	NextPageURL() string
-}
-
 // BaseResponse has all possible attributes that any response can use. It's intended to be embedded in a
 // domain specific response struct.
 type BaseResponse struct {
@@ -26,7 +20,7 @@ type PaginationHooks struct {
 	NextURL string `json:"next_url,omitempty"`
 }
 
-func (p PaginationHooks) NextPageURL() string {
+func (p PaginationHooks) NextPage() string {
 	return p.NextURL
 }
 

--- a/rest/quotes/quotes.go
+++ b/rest/quotes/quotes.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/client"
+	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
@@ -15,7 +16,7 @@ type Client struct {
 
 // ListQuotesIter is an iterator for the ListQuotes method.
 type ListQuotesIter struct {
-	models.Iter
+	iter.Iter
 }
 
 // Quote returns the current result that the iterator points to.
@@ -38,13 +39,8 @@ func (it *ListQuotesIter) Quote() models.Quote {
 //       return err
 //   }
 func (c *Client) ListQuotes(ctx context.Context, params *models.ListQuotesParams, options ...models.RequestOption) *ListQuotesIter {
-	uri, err := c.EncodeParams(models.ListQuotesPath, params)
-	if err != nil {
-		return &ListQuotesIter{Iter: models.NewIterErr(ctx, err)}
-	}
-
 	return &ListQuotesIter{
-		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: iter.NewIter(ctx, models.ListQuotesPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
 			res := &models.ListQuotesResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/reference/conditions.go
+++ b/rest/reference/conditions.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 // ListConditionsIter is an iterator for the ListConditions method.
 type ListConditionsIter struct {
-	models.Iter
+	iter.Iter
 }
 
 // Condition returns the current result that the iterator points to.
@@ -32,13 +33,8 @@ func (it *ListConditionsIter) Condition() models.Condition {
 //       return err
 //   }
 func (c *Client) ListConditions(ctx context.Context, params *models.ListConditionsParams, options ...models.RequestOption) *ListConditionsIter {
-	uri, err := c.EncodeParams(models.ListConditionsPath, params)
-	if err != nil {
-		return &ListConditionsIter{Iter: models.NewIterErr(ctx, err)}
-	}
-
 	return &ListConditionsIter{
-		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: iter.NewIter(ctx, models.ListConditionsPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
 			res := &models.ListConditionsResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/reference/dividends.go
+++ b/rest/reference/dividends.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 // ListDividendsIter is an iterator for the ListDividends method.
 type ListDividendsIter struct {
-	models.Iter
+	iter.Iter
 }
 
 // Dividend returns the current result that the iterator points to.
@@ -32,13 +33,8 @@ func (it *ListDividendsIter) Dividend() models.Dividend {
 //       return err
 //   }
 func (c *Client) ListDividends(ctx context.Context, params *models.ListDividendsParams, options ...models.RequestOption) *ListDividendsIter {
-	uri, err := c.EncodeParams(models.ListDividendsPath, params)
-	if err != nil {
-		return &ListDividendsIter{Iter: models.NewIterErr(ctx, err)}
-	}
-
 	return &ListDividendsIter{
-		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: iter.NewIter(ctx, models.ListDividendsPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
 			res := &models.ListDividendsResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/reference/splits.go
+++ b/rest/reference/splits.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 // ListSplitsIter is an iterator for the ListSplits method.
 type ListSplitsIter struct {
-	models.Iter
+	iter.Iter
 }
 
 // Split returns the current result that the iterator points to.
@@ -32,13 +33,8 @@ func (it *ListSplitsIter) Split() models.Split {
 //       return err
 //   }
 func (c *Client) ListSplits(ctx context.Context, params *models.ListSplitsParams, options ...models.RequestOption) *ListSplitsIter {
-	uri, err := c.EncodeParams(models.ListSplitsPath, params)
-	if err != nil {
-		return &ListSplitsIter{Iter: models.NewIterErr(ctx, err)}
-	}
-
 	return &ListSplitsIter{
-		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: iter.NewIter(ctx, models.ListSplitsPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
 			res := &models.ListSplitsResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/reference/tickers.go
+++ b/rest/reference/tickers.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 // ListTickersIter is an iterator for the ListTickers method.
 type ListTickersIter struct {
-	models.Iter
+	iter.Iter
 }
 
 // Ticker returns the current result that the iterator points to.
@@ -32,13 +33,8 @@ func (it *ListTickersIter) Ticker() models.Ticker {
 //       return err
 //   }
 func (c *Client) ListTickers(ctx context.Context, params *models.ListTickersParams, options ...models.RequestOption) *ListTickersIter {
-	uri, err := c.EncodeParams(models.ListTickersPath, params)
-	if err != nil {
-		return &ListTickersIter{Iter: models.NewIterErr(ctx, err)}
-	}
-
 	return &ListTickersIter{
-		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: iter.NewIter(ctx, models.ListTickersPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
 			res := &models.ListTickersResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 

--- a/rest/trades/trades.go
+++ b/rest/trades/trades.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/client"
+	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
@@ -15,7 +16,7 @@ type Client struct {
 
 // ListTradesIter is an iterator for the ListTickers method.
 type ListTradesIter struct {
-	models.Iter
+	iter.Iter
 }
 
 // Trade returns the current result that the iterator points to.
@@ -38,13 +39,8 @@ func (it *ListTradesIter) Trade() models.Trade {
 //       return err
 //   }
 func (c *Client) ListTrades(ctx context.Context, params *models.ListTradesParams, options ...models.RequestOption) *ListTradesIter {
-	uri, err := c.EncodeParams(models.ListTradesPath, params)
-	if err != nil {
-		return &ListTradesIter{Iter: models.NewIterErr(ctx, err)}
-	}
-
 	return &ListTradesIter{
-		Iter: models.NewIter(ctx, uri, func(uri string) (models.ListResponse, []interface{}, error) {
+		Iter: iter.NewIter(ctx, models.ListTradesPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
 			res := &models.ListTradesResponse{}
 			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
 


### PR DESCRIPTION
i wanted to clean up the iter interface: `NewIter(ctx context.Context, path string, params interface{}, query Query) Iter`. to get there, it made sense to break the iter and encoder stuff into separate packages.