### PR TITLE
make iter generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ iter := c.Trades.ListTrades(context.Background(), params)
 
 // iter.Next() advances the iterator to the next value in the list
 for iter.Next() {
-    log.Print(iter.Trade()) // do something with the current value
+    log.Print(iter.Item()) // do something with the current value
 }
 
 // if the loop breaks, it has either reached the end of the list or an error has occurred

--- a/rest/quotes_test.go
+++ b/rest/quotes_test.go
@@ -68,19 +68,19 @@ func TestListQuotes(t *testing.T) {
 
 	// iter creation
 	assert.Nil(t, iter.Err())
-	assert.NotNil(t, iter.Quote())
+	assert.NotNil(t, iter.Item())
 
 	// first item
 	assert.True(t, iter.Next())
 	assert.Nil(t, iter.Err())
-	b, err := json.MarshalIndent(iter.Quote(), "", "\t")
+	b, err := json.MarshalIndent(iter.Item(), "", "\t")
 	assert.Nil(t, err)
 	assert.Equal(t, quote1, string(b))
 
 	// second item
 	assert.True(t, iter.Next())
 	assert.Nil(t, iter.Err())
-	b, err = json.MarshalIndent(iter.Quote(), "", "\t")
+	b, err = json.MarshalIndent(iter.Item(), "", "\t")
 	assert.Nil(t, err)
 	assert.Equal(t, quote2, string(b))
 

--- a/rest/reference.go
+++ b/rest/reference.go
@@ -31,44 +31,22 @@ type ReferenceClient struct {
 	client.Client
 }
 
-// ListTickersIter is an iterator for the ListTickers method.
-type ListTickersIter struct {
-	iter.Iter
-}
-
-// Ticker returns the current result that the iterator points to.
-func (it *ListTickersIter) Ticker() models.Ticker {
-	if it.Item() != nil {
-		return it.Item().(models.Ticker)
-	}
-	return models.Ticker{}
-}
-
 // ListTickers retrieves reference tickers.
 // For more details see https://polygon.io/docs/stocks/get_v3_reference_tickers__ticker.
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListTickers(context.TODO(), params, opts...)
 //   for iter.Next() {
-//       // do something with the current value
-//       log.Print(iter.Ticker())
+//       log.Print(iter.Item()) // do something with the current value
 //   }
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *ReferenceClient) ListTickers(ctx context.Context, params *models.ListTickersParams, options ...models.RequestOption) *ListTickersIter {
-	return &ListTickersIter{
-		Iter: iter.NewIter(ctx, ListTickersPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
-			res := &models.ListTickersResponse{}
-			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
-
-			results := make([]interface{}, len(res.Results))
-			for i, v := range res.Results {
-				results[i] = v
-			}
-
-			return res, results, err
-		}),
-	}
+func (c *ReferenceClient) ListTickers(ctx context.Context, params *models.ListTickersParams, options ...models.RequestOption) *iter.Iter[models.Ticker] {
+	return iter.NewIter(ctx, ListTickersPath, params, func(uri string) (iter.ListResponse, []models.Ticker, error) {
+		res := &models.ListTickersResponse{}
+		err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
 }
 
 // GetTickerDetails retrieves details for a specified ticker.
@@ -103,57 +81,22 @@ func (c *ReferenceClient) GetMarketStatus(ctx context.Context, options ...models
 	return res, err
 }
 
-// ListSplitsIter is an iterator for the ListSplits method.
-type ListSplitsIter struct {
-	iter.Iter
-}
-
-// Split returns the current result that the iterator points to.
-func (it *ListSplitsIter) Split() models.Split {
-	if it.Item() != nil {
-		return it.Item().(models.Split)
-	}
-	return models.Split{}
-}
-
 // ListSplits retrieves reference splits.
 // For more details see https://polygon.io/docs/stocks/get_v3_reference_splits.
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListSplits(context.TODO(), params, opts...)
 //   for iter.Next() {
-//       // do something with the current value
-//       log.Print(iter.Split())
+//       log.Print(iter.Item()) // do something with the current value
 //   }
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *ReferenceClient) ListSplits(ctx context.Context, params *models.ListSplitsParams, options ...models.RequestOption) *ListSplitsIter {
-	return &ListSplitsIter{
-		Iter: iter.NewIter(ctx, ListSplitsPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
-			res := &models.ListSplitsResponse{}
-			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
-
-			results := make([]interface{}, len(res.Results))
-			for i, v := range res.Results {
-				results[i] = v
-			}
-
-			return res, results, err
-		}),
-	}
-}
-
-// ListDividendsIter is an iterator for the ListDividends method.
-type ListDividendsIter struct {
-	iter.Iter
-}
-
-// Dividend returns the current result that the iterator points to.
-func (it *ListDividendsIter) Dividend() models.Dividend {
-	if it.Item() != nil {
-		return it.Item().(models.Dividend)
-	}
-	return models.Dividend{}
+func (c *ReferenceClient) ListSplits(ctx context.Context, params *models.ListSplitsParams, options ...models.RequestOption) *iter.Iter[models.Split] {
+	return iter.NewIter(ctx, ListSplitsPath, params, func(uri string) (iter.ListResponse, []models.Split, error) {
+		res := &models.ListSplitsResponse{}
+		err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
 }
 
 // ListDividends retrieves reference dividends.
@@ -161,39 +104,17 @@ func (it *ListDividendsIter) Dividend() models.Dividend {
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListDividends(context.TODO(), params, opts...)
 //   for iter.Next() {
-//       // do something with the current value
-//       log.Print(iter.Dividend())
+//       log.Print(iter.Item()) // do something with the current value
 //   }
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *ReferenceClient) ListDividends(ctx context.Context, params *models.ListDividendsParams, options ...models.RequestOption) *ListDividendsIter {
-	return &ListDividendsIter{
-		Iter: iter.NewIter(ctx, ListDividendsPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
-			res := &models.ListDividendsResponse{}
-			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
-
-			results := make([]interface{}, len(res.Results))
-			for i, v := range res.Results {
-				results[i] = v
-			}
-
-			return res, results, err
-		}),
-	}
-}
-
-// ListConditionsIter is an iterator for the ListConditions method.
-type ListConditionsIter struct {
-	iter.Iter
-}
-
-// Condition returns the current result that the iterator points to.
-func (it *ListConditionsIter) Condition() models.Condition {
-	if it.Item() != nil {
-		return it.Item().(models.Condition)
-	}
-	return models.Condition{}
+func (c *ReferenceClient) ListDividends(ctx context.Context, params *models.ListDividendsParams, options ...models.RequestOption) *iter.Iter[models.Dividend] {
+	return iter.NewIter(ctx, ListDividendsPath, params, func(uri string) (iter.ListResponse, []models.Dividend, error) {
+		res := &models.ListDividendsResponse{}
+		err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
 }
 
 // ListConditions retrieves reference conditions.
@@ -201,26 +122,17 @@ func (it *ListConditionsIter) Condition() models.Condition {
 // This method returns an iterator that should be used to access the results via this pattern:
 //   iter, err := c.ListConditions(context.TODO(), params, opts...)
 //   for iter.Next() {
-//       // do something with the current value
-//       log.Print(iter.Condition())
+//       log.Print(iter.Item()) // do something with the current value
 //   }
 //   if iter.Err() != nil {
 //       return err
 //   }
-func (c *ReferenceClient) ListConditions(ctx context.Context, params *models.ListConditionsParams, options ...models.RequestOption) *ListConditionsIter {
-	return &ListConditionsIter{
-		Iter: iter.NewIter(ctx, ListConditionsPath, params, func(uri string) (iter.ListResponse, []interface{}, error) {
-			res := &models.ListConditionsResponse{}
-			err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
-
-			results := make([]interface{}, len(res.Results))
-			for i, v := range res.Results {
-				results[i] = v
-			}
-
-			return res, results, err
-		}),
-	}
+func (c *ReferenceClient) ListConditions(ctx context.Context, params *models.ListConditionsParams, options ...models.RequestOption) *iter.Iter[models.Condition] {
+	return iter.NewIter(ctx, ListConditionsPath, params, func(uri string) (iter.ListResponse, []models.Condition, error) {
+		res := &models.ListConditionsResponse{}
+		err := c.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
 }
 
 // GetExchanges lists all exchanges that Polygon knows about.

--- a/rest/reference_test.go
+++ b/rest/reference_test.go
@@ -53,12 +53,12 @@ func TestListTickers(t *testing.T) {
 
 	// iter creation
 	assert.Nil(t, iter.Err())
-	assert.NotNil(t, iter.Ticker())
+	assert.NotNil(t, iter.Item())
 
 	// first item
 	assert.True(t, iter.Next())
 	assert.Nil(t, iter.Err())
-	b, err := json.MarshalIndent(iter.Ticker(), "", "\t")
+	b, err := json.MarshalIndent(iter.Item(), "", "\t")
 	assert.Nil(t, err)
 	assert.Equal(t, ticker1, string(b))
 
@@ -261,12 +261,12 @@ func TestListSplits(t *testing.T) {
 
 	// iter creation
 	assert.Nil(t, iter.Err())
-	assert.NotNil(t, iter.Split())
+	assert.NotNil(t, iter.Item())
 
 	// first item
 	assert.True(t, iter.Next())
 	assert.Nil(t, iter.Err())
-	b, err := json.MarshalIndent(iter.Split(), "", "\t")
+	b, err := json.MarshalIndent(iter.Item(), "", "\t")
 	assert.Nil(t, err)
 	assert.Equal(t, split1, string(b))
 
@@ -307,12 +307,12 @@ func TestListDividends(t *testing.T) {
 
 	// iter creation
 	assert.Nil(t, iter.Err())
-	assert.NotNil(t, iter.Dividend())
+	assert.NotNil(t, iter.Item())
 
 	// first item
 	assert.True(t, iter.Next())
 	assert.Nil(t, iter.Err())
-	b, err := json.MarshalIndent(iter.Dividend(), "", "\t")
+	b, err := json.MarshalIndent(iter.Item(), "", "\t")
 	assert.Nil(t, err)
 	assert.Equal(t, dividend1, string(b))
 
@@ -369,12 +369,12 @@ func TestListConditions(t *testing.T) {
 
 	// iter creation
 	assert.Nil(t, iter.Err())
-	assert.NotNil(t, iter.Condition())
+	assert.NotNil(t, iter.Item())
 
 	// first item
 	assert.True(t, iter.Next())
 	assert.Nil(t, iter.Err())
-	b, err := json.MarshalIndent(iter.Condition(), "", "\t")
+	b, err := json.MarshalIndent(iter.Item(), "", "\t")
 	assert.Nil(t, err)
 	assert.Equal(t, condition, string(b))
 

--- a/rest/trades_test.go
+++ b/rest/trades_test.go
@@ -66,19 +66,19 @@ func TestListTrades(t *testing.T) {
 
 	// iter creation
 	assert.Nil(t, iter.Err())
-	assert.NotNil(t, iter.Trade())
+	assert.NotNil(t, iter.Item())
 
 	// first item
 	assert.True(t, iter.Next())
 	assert.Nil(t, iter.Err())
-	b, err := json.MarshalIndent(iter.Trade(), "", "\t")
+	b, err := json.MarshalIndent(iter.Item(), "", "\t")
 	assert.Nil(t, err)
 	assert.Equal(t, trade1, string(b))
 
 	// second item
 	assert.True(t, iter.Next())
 	assert.Nil(t, iter.Err())
-	b, err = json.MarshalIndent(iter.Trade(), "", "\t")
+	b, err = json.MarshalIndent(iter.Item(), "", "\t")
 	assert.Nil(t, err)
 	assert.Equal(t, trade2, string(b))
 


### PR DESCRIPTION
Modifying our iterator to use generics. This eliminates the need to copy the data and also cleans up the public interface nicely imo.