### PR TITLE
expose output channel and guard against user closing it

### DIFF
--- a/websocket/polygon.go
+++ b/websocket/polygon.go
@@ -258,11 +258,6 @@ func (c *Client) closeOutput() {
 	close(c.output)
 }
 
-func Close(ch chan int) {
-	defer func() { recover() }()
-	close(ch)
-}
-
 func (c *Client) close(reconnect bool) {
 	if c.conn == nil {
 		return

--- a/websocket/polygon_test.go
+++ b/websocket/polygon_test.go
@@ -89,10 +89,6 @@ func TestConnectAuthSuccess(t *testing.T) {
 	// closing before connecting shouldn't do anthing
 	c.Close()
 
-	// accessing output early shouldn't do anything
-	out := c.Output()
-	assert.Nil(t, out)
-
 	// connect successfully
 	err = c.Connect()
 	assert.Nil(t, err)


### PR DESCRIPTION
The original design was causing this client to be CPU hungry. Attempting to expose the channel in a relatively safe way. There's no way to stop the user from closing it but the client should still recover the panic and close gracefully.