### PR TITLE
add error channel to signal fatal errors

### DIFF
--- a/websocket/polygon_test.go
+++ b/websocket/polygon_test.go
@@ -126,6 +126,9 @@ func TestConnectAuthFailure(t *testing.T) {
 
 	err = c.Connect()
 	assert.Nil(t, err)
+
+	err = <-c.Error()
+	assert.NotNil(t, err)
 }
 
 func TestConnectRetryFailure(t *testing.T) {


### PR DESCRIPTION
Got some feedback from Aaron on this. If a user doesn't provide a working API key, we don't really signal to them that a fatal error occurred. It is logged but it would be nice to push fatal errors to this channel as well. I decided not to guard against users closing the err channel (they're seriously doing something wrong if they do that anyway).