### PR TITLE
fix: use correct wording

### DIFF
--- a/websocket/models/models.go
+++ b/websocket/models/models.go
@@ -147,7 +147,7 @@ type CryptoTrade struct {
 	EventType
 
 	// The crypto pair.
-	Symbol string `json:"sym,omitempty"`
+	Pair string `json:"pair,omitempty"`
 
 	// The crypto exchange ID.
 	Exchange int32 `json:"x,omitempty"`


### PR DESCRIPTION
Hi there,

this fixes a wording issue in CryptoTrade struct.

https://polygon.io/docs/crypto/ws_crypto_xt