### PR TITLE
Change split_from and split_to from int64 to float64

### DIFF
--- a/rest/models/splits.go
+++ b/rest/models/splits.go
@@ -91,7 +91,7 @@ type ListSplitsResponse struct {
 // Split contains detailed information on a specified stock split.
 type Split struct {
 	ExecutionDate string `json:"execution_date,omitempty"`
-	SplitFrom     int64  `json:"split_from,omitempty"`
-	SplitTo       int64  `json:"split_to,omitempty"`
+	SplitFrom     float64  `json:"split_from,omitempty"`
+	SplitTo       float64  `json:"split_to,omitempty"`
 	Ticker        string `json:"ticker,omitempty"`
 }

--- a/rest/reference_test.go
+++ b/rest/reference_test.go
@@ -335,7 +335,7 @@ func TestListSplits(t *testing.T) {
 
 	split := `{
 	"execution_date": "2020-08-31",
-	"split_from": 1,
+	"split_from": 1.0,
 	"split_to": 4,
 	"ticker": "AAPL"
 }`


### PR DESCRIPTION
Bugfix for this split:
```
2022/10/10 13:26:39.854395 ERROR RESTY json: cannot unmarshal number 3.83227428463e+11 into Go struct field Split.results.split_from of type int64, Attempt 1
Error: failed to execute request: json: cannot unmarshal number 3.83227428463e+11 into Go struct field Split.results.split_from of type int64
```

To match the models in [go-apps-reference-splits](https://github.com/polygon-io/go-apps-reference-splits/blob/master/models/models.go#L6).