### PR TITLE
Using string instead of int for Exchange in ListTickersParams

### DIFF
--- a/rest/models/tickers.go
+++ b/rest/models/tickers.go
@@ -18,7 +18,7 @@ type ListTickersParams struct {
 
 	// Specify the primary exchange of the asset in the ISO code format. Find more information about the ISO codes at
 	// the ISO org website. Defaults to empty string which queries all exchanges.
-	Exchange *int `query:"exchange"`
+	Exchange *string `query:"exchange"`
 
 	// Specify the CUSIP code of the asset you want to search for. Find more information about CUSIP codes at their
 	// website. Defaults to empty string which queries all CUSIPs.
@@ -76,7 +76,7 @@ func (p ListTickersParams) WithMarket(q AssetClass) *ListTickersParams {
 	return &p
 }
 
-func (p ListTickersParams) WithExchange(q int) *ListTickersParams {
+func (p ListTickersParams) WithExchange(q string) *ListTickersParams {
 	p.Exchange = &q
 	return &p
 }

--- a/rest/reference_test.go
+++ b/rest/reference_test.go
@@ -43,11 +43,11 @@ func TestListTickers(t *testing.T) {
 	]
 }`
 
-	registerResponder("https://api.polygon.io/v3/reference/tickers?active=true&cik=5&cusip=10&date=2021-07-22&exchange=4&limit=2&market=stocks&order=asc&sort=ticker&type=CS", expectedResponse)
+	registerResponder("https://api.polygon.io/v3/reference/tickers?active=true&cik=5&cusip=10&date=2021-07-22&exchange=XNAS&limit=2&market=stocks&order=asc&sort=ticker&type=CS", expectedResponse)
 	registerResponder("https://api.polygon.io/v3/reference/tickers?cursor=YWN0aXZlPXRydWUmZGF0ZT0yMDIxLTA0LTI1JmxpbWl0PTEmb3JkZXI9YXNjJnBhZ2VfbWFya2VyPUElN0M5YWRjMjY0ZTgyM2E1ZjBiOGUyNDc5YmZiOGE1YmYwNDVkYzU0YjgwMDcyMWE2YmI1ZjBjMjQwMjU4MjFmNGZiJnNvcnQ9dGlja2Vy", "{}")
 	iter := c.ListTickers(context.Background(), models.ListTickersParams{}.
 		WithType("CS").WithMarket(models.AssetStocks).
-		WithExchange(4).WithCUSIP(10).WithCIK(5).
+		WithExchange("XNAS").WithCUSIP(10).WithCIK(5).
 		WithDate(models.Date(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))).WithActive(true).
 		WithSort(models.TickerSymbol).WithOrder(models.Asc).WithLimit(2))
 


### PR DESCRIPTION
fixes https://github.com/polygon-io/client-go/issues/210