### PR TITLE
implement list aggs

### DIFF
--- a/rest/aggs.go
+++ b/rest/aggs.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 
 	"github.com/polygon-io/client-go/rest/client"
+	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
 )
 
 const (
+	ListAggsPath             = "/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}"
 	GetAggsPath              = "/v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}"
 	GetGroupedDailyAggsPath  = "/v2/aggs/grouped/locale/{locale}/market/{marketType}/{date}"
 	GetDailyOpenCloseAggPath = "/v1/open-close/{ticker}/{date}"
@@ -20,9 +22,33 @@ type AggsClient struct {
 	client.Client
 }
 
+// ListAggs retrieves aggregate bars for a specified ticker over a given date range in custom time window sizes.
+// For example, if timespan = 'minute' and multiplier = '5' then 5-minute bars will be returned.
+// For more details see https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to.
+//
+// This method returns an iterator that should be used to access the results via this pattern:
+//
+//	iter := c.ListAggs(context.TODO(), params, opts...)
+//	for iter.Next() {
+//		log.Print(iter.Item()) // do something with the current value
+//	}
+//	if iter.Err() != nil {
+//		return iter.Err()
+//	}
+func (ac *AggsClient) ListAggs(ctx context.Context, params *models.ListAggsParams, options ...models.RequestOption) *iter.Iter[models.Agg] {
+	return iter.NewIter(ctx, ListAggsPath, params, func(uri string) (iter.ListResponse, []models.Agg, error) {
+		res := &models.ListAggsResponse{}
+		err := ac.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}
+
 // GetAggs retrieves aggregate bars for a specified ticker over a given date range in custom time window sizes.
 // For example, if timespan = 'minute' and multiplier = '5' then 5-minute bars will be returned.
 // For more details see https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to.
+//
+// Deprecated: This method does not return an iterator and forces users to handle pagination manually. Use
+// pkg.go.dev/github.com/polygon-io/client-go/rest#AggsClient.ListAggs instead if you want automatic pagination.
 func (ac *AggsClient) GetAggs(ctx context.Context, params *models.GetAggsParams, opts ...models.RequestOption) (*models.GetAggsResponse, error) {
 	res := &models.GetAggsResponse{}
 	err := ac.Call(ctx, http.MethodGet, GetAggsPath, params, res, opts...)

--- a/rest/example/launchpad/main.go
+++ b/rest/example/launchpad/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"context"
-	polygon "github.com/polygon-io/client-go/rest"
-	"github.com/polygon-io/client-go/rest/models"
 	"log"
 	"os"
 	"time"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
 )
 
 func main() {
@@ -16,7 +17,7 @@ func main() {
 func getAggregateBarsLaunchpad() {
 	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
 
-	params3 := &models.GetAggsParams{
+	params := &models.ListAggsParams{
 		Ticker:     "CORN",
 		Multiplier: 1,
 		Timespan:   models.Day,
@@ -24,12 +25,11 @@ func getAggregateBarsLaunchpad() {
 		To:         models.Millis(time.Now()),
 	}
 
-	res, err := c.GetAggs(context.Background(), params3,
-		models.RequiredEdgeHeaders("EDGE_USER_ID", "EDGE_USER_IP_ADDRESS"),
-		models.EdgeUserAgent("EDGE_USER_AGENT"),
-	)
-	if err != nil {
-		log.Fatal(err)
+	iter := c.ListAggs(context.TODO(), params)
+	for iter.Next() {
+		log.Print(iter.Item()) // do something with the current value
 	}
-	log.Print(res) // do something with the result
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
 }

--- a/rest/models/aggs.go
+++ b/rest/models/aggs.go
@@ -1,5 +1,61 @@
 package models
 
+// ListAggsParams is the set of parameters for the ListAggs method.
+type ListAggsParams struct {
+	// The ticker symbol of the stock/equity.
+	Ticker string `validate:"required" path:"ticker"`
+
+	// The size of the timespan multiplier.
+	Multiplier int `validate:"required" path:"multiplier"`
+
+	// The size of the time window.
+	Timespan Timespan `validate:"required" path:"timespan"`
+
+	// The start of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.
+	From Millis `validate:"required" path:"from"`
+
+	// The end of the aggregate time window. Either a date with the format YYYY-MM-DD or a millisecond timestamp.
+	To Millis `validate:"required" path:"to"`
+
+	// Whether or not the results are adjusted for splits. By default, results are adjusted. Set this to false to get
+	// results that are NOT adjusted for splits.
+	Adjusted *bool `query:"adjusted"`
+
+	// Order the results by timestamp. asc will return results in ascending order (oldest at the top), desc will return
+	// results in descending order (newest at the top).
+	Order *Order `query:"sort"`
+
+	// Limits the number of base aggregates queried to create the aggregate results. Max 50000 and Default 5000. Read
+	// more about how limit is used to calculate aggregate results in our article on Aggregate Data API Improvements:
+	// https://polygon.io/blog/aggs-api-updates/.
+	Limit *int `query:"limit"`
+}
+
+func (p ListAggsParams) WithAdjusted(q bool) *ListAggsParams {
+	p.Adjusted = &q
+	return &p
+}
+
+func (p ListAggsParams) WithOrder(q Order) *ListAggsParams {
+	p.Order = &q
+	return &p
+}
+
+func (p ListAggsParams) WithLimit(q int) *ListAggsParams {
+	p.Limit = &q
+	return &p
+}
+
+// ListAggsResponse is the response returned by the ListAggs method.
+type ListAggsResponse struct {
+	BaseResponse
+	Ticker       string `json:"ticker,omitempty"`
+	QueryCount   int    `json:"queryCount,omitempty"`
+	ResultsCount int    `json:"resultsCount,omitempty"`
+	Adjusted     bool   `json:"adjusted"`
+	Results      []Agg  `json:"results,omitempty"`
+}
+
 // GetAggsParams is the set of parameters for the GetAggs method.
 type GetAggsParams struct {
 	// The ticker symbol of the stock/equity.


### PR DESCRIPTION
This PR adds a `ListAggs` method that handles pagination automatically. It also deprecates `GetAggs` (it will now be hidden in the godoc but still available to use for now). I decided to duplicate the models so that we won't break anyone using the new method when we remove `GetAggs`.

This PR shouldn't be merged until aggs pagination is released.