### PR TITLE
change response date fields from string to Date type

### DIFF
--- a/rest/models/dividends.go
+++ b/rest/models/dividends.go
@@ -161,11 +161,11 @@ type ListDividendsResponse struct {
 // Dividend contains detailed information on a specified stock dividend.
 type Dividend struct {
 	CashAmount      float64 `json:"cash_amount,omitempty"`
-	DeclarationDate string  `json:"declaration_date,omitempty"`
+	DeclarationDate Date    `json:"declaration_date,omitempty"`
 	DividendType    string  `json:"dividend_type,omitempty"`
 	ExDividendDate  string  `json:"ex_dividend_date,omitempty"`
 	Frequency       int64   `json:"frequency,omitempty"`
-	PayDate         string  `json:"pay_date,omitempty"`
-	RecordDate      string  `json:"record_date,omitempty"`
+	PayDate         Date    `json:"pay_date,omitempty"`
+	RecordDate      Date    `json:"record_date,omitempty"`
 	Ticker          string  `json:"ticker,omitempty"`
 }

--- a/rest/models/splits.go
+++ b/rest/models/splits.go
@@ -90,7 +90,7 @@ type ListSplitsResponse struct {
 
 // Split contains detailed information on a specified stock split.
 type Split struct {
-	ExecutionDate string  `json:"execution_date,omitempty"`
+	ExecutionDate Date    `json:"execution_date,omitempty"`
 	SplitFrom     float64 `json:"split_from,omitempty"`
 	SplitTo       float64 `json:"split_to,omitempty"`
 	Ticker        string  `json:"ticker,omitempty"`

--- a/rest/models/tickers.go
+++ b/rest/models/tickers.go
@@ -383,7 +383,7 @@ type TickerEventResult struct {
 
 // TickerEvent contains the data for the different type of ticker events that could occur.
 type TickerEvent struct {
-	Date         string             `json:"date"`
+	Date         Date               `json:"date"`
 	Type         string             `json:"type"`
 	TickerChange *TickerChangeEvent `json:"ticker_change,omitempty"`
 }


### PR DESCRIPTION
Proposing a few breaking changes to some reference data response types that were brought to our attention in #232. In the rest of our models, we use our time aliases (e.g. `Nanos`) in our response types but these were implemented as `string` by mistake. We'll have to call out these breaking changes in the release notes.