### PR TITLE
Fix up behavior of Code Coverage GH Action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,3 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52
+      - name: gofmt
+        run: |
+          go fmt ./...
+          git diff --exit-code


### PR DESCRIPTION
- Code Coverage GH Action: Remove unnecessary merge commit by rebasing
- Just run git push, not something fancy
- change readme to trick it
- Fix git push
- Be better about getting current branch
- Use built in feature to get branch name
