### PR TITLE
Add examples for stocks and options

### DIFF
--- a/rest/example/options-aggregates-bars/main.go
+++ b/rest/example/options-aggregates-bars/main.go
@@ -1,0 +1,39 @@
+// options - Aggregates (Bars)
+// https://polygon.io/docs/options/get_v2_aggs_ticker__optionsticker__range__multiplier___timespan___from___to
+// https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetAggsParams{
+		Ticker:     "O:SPY251219C00650000",
+		Multiplier: 1,
+		Timespan:   "day",
+		From:       models.Millis(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+		To:         models.Millis(time.Date(2023, 3, 9, 0, 0, 0, 0, time.UTC)),
+	}.WithOrder(models.Desc).WithLimit(2).WithAdjusted(true)
+
+	// make request
+	res, err := c.GetAggs(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-aggregates-bars/main.go
+++ b/rest/example/options-aggregates-bars/main.go
@@ -1,4 +1,4 @@
-// options - Aggregates (Bars)
+// Options - Aggregates (Bars)
 // https://polygon.io/docs/options/get_v2_aggs_ticker__optionsticker__range__multiplier___timespan___from___to
 // https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
 package main
@@ -19,21 +19,23 @@ func main() {
 	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
 
 	// set params
-	params := models.GetAggsParams{
+	params := models.ListAggsParams{
 		Ticker:     "O:SPY251219C00650000",
 		Multiplier: 1,
 		Timespan:   "day",
 		From:       models.Millis(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
 		To:         models.Millis(time.Date(2023, 3, 9, 0, 0, 0, 0, time.UTC)),
-	}.WithOrder(models.Desc).WithLimit(2).WithAdjusted(true)
+	}.WithOrder(models.Desc).WithLimit(50000).WithAdjusted(true)
 
 	// make request
-	res, err := c.GetAggs(context.Background(), params)
-	if err != nil {
-		log.Fatal(err)
-	}
+	iter := c.ListAggs(context.Background(), params)
 
 	// do something with the result
-	log.Print(res) 
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
 
 }

--- a/rest/example/options-conditions/main.go
+++ b/rest/example/options-conditions/main.go
@@ -1,4 +1,4 @@
-// options - conditions
+// Options - Conditions
 // https://polygon.io/docs/options/get_v3_reference_conditions
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-conditions/main.go
+++ b/rest/example/options-conditions/main.go
@@ -1,0 +1,37 @@
+// options - conditions
+// https://polygon.io/docs/options/get_v3_reference_conditions
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListConditionsParams{}.
+		WithAssetClass(models.AssetOptions).
+		WithDataType(models.DataTrade).
+		WithLimit(1000)
+
+	// make request
+	iter := c.ListConditions(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/options-contract/main.go
+++ b/rest/example/options-contract/main.go
@@ -1,0 +1,35 @@
+// options - options contract
+// https://polygon.io/docs/options/get_v3_reference_options_contracts__options_ticker
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetOptionsContractParams{
+		Ticker: "O:EVRI240119C00002500",
+	}.WithAsOf(models.Date(time.Date(2022, 5, 16, 0, 0, 0, 0, time.Local)))
+
+	// make request
+	res, err := c.GetOptionsContract(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-contract/main.go
+++ b/rest/example/options-contract/main.go
@@ -1,4 +1,4 @@
-// options - options contract
+// Options - Options Contract
 // https://polygon.io/docs/options/get_v3_reference_options_contracts__options_ticker
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-contracts/main.go
+++ b/rest/example/options-contracts/main.go
@@ -1,0 +1,37 @@
+// options - options contracts
+// https://polygon.io/docs/options/get_v3_reference_options_contracts
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListOptionsContractsParams{}.
+		WithUnderlyingTicker(models.EQ, "HCP").
+		WithContractType("call").
+		WithLimit(1000)
+
+	// make request
+	iter := c.ListOptionsContracts(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/options-contracts/main.go
+++ b/rest/example/options-contracts/main.go
@@ -1,4 +1,4 @@
-// options - options contracts
+// Options - Options Contracts
 // https://polygon.io/docs/options/get_v3_reference_options_contracts
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-daily-open-close/main.go
+++ b/rest/example/options-daily-open-close/main.go
@@ -1,0 +1,36 @@
+// options - Daily Open/Close
+// https://polygon.io/docs/options/get_v1_open-close__optionsticker___date
+// https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetDailyOpenCloseAggParams{
+		Ticker: "O:SPY251219C00650000",
+		Date:   models.Date(time.Date(2023, 2, 22, 0, 0, 0, 0, time.Local)),
+	}.WithAdjusted(true)
+
+	// make request
+	res, err := c.GetDailyOpenCloseAgg(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-daily-open-close/main.go
+++ b/rest/example/options-daily-open-close/main.go
@@ -1,4 +1,4 @@
-// options - Daily Open/Close
+// Options - Daily Open/Close
 // https://polygon.io/docs/options/get_v1_open-close__optionsticker___date
 // https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
 package main

--- a/rest/example/options-exchanges/main.go
+++ b/rest/example/options-exchanges/main.go
@@ -1,0 +1,34 @@
+// options - exchanges
+// https://polygon.io/docs/options/get_v3_reference_exchanges
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetExchangesParams{}.
+		WithAssetClass(models.AssetOptions).
+		WithLocale(models.US)
+
+	// make request
+	res, err := c.GetExchanges(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-exchanges/main.go
+++ b/rest/example/options-exchanges/main.go
@@ -1,4 +1,4 @@
-// options - exchanges
+// Options - Exchanges
 // https://polygon.io/docs/options/get_v3_reference_exchanges
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-last-trade/main.go
+++ b/rest/example/options-last-trade/main.go
@@ -1,4 +1,4 @@
-// options - get last trade
+// Options - Last Trade
 // https://polygon.io/docs/options/get_v2_last_trade__optionsticker
 // https://github.com/polygon-io/client-go/blob/master/rest/trades.go
 package main

--- a/rest/example/options-last-trade/main.go
+++ b/rest/example/options-last-trade/main.go
@@ -1,0 +1,34 @@
+// options - get last trade
+// https://polygon.io/docs/options/get_v2_last_trade__optionsticker
+// https://github.com/polygon-io/client-go/blob/master/rest/trades.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetLastTradeParams{
+		Ticker:     "O:TSLA210903C00700000",
+	}
+
+	// make request
+	res, err := c.GetLastTrade(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-market-holidays/main.go
+++ b/rest/example/options-market-holidays/main.go
@@ -1,4 +1,4 @@
-// options - market holidays
+// Options - Market Holidays
 // https://polygon.io/docs/options/get_v1_marketstatus_upcoming
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-market-holidays/main.go
+++ b/rest/example/options-market-holidays/main.go
@@ -1,0 +1,28 @@
+// options - market holidays
+// https://polygon.io/docs/options/get_v1_marketstatus_upcoming
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// make request
+	res, err := c.GetMarketHolidays(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-market-status/main.go
+++ b/rest/example/options-market-status/main.go
@@ -1,4 +1,4 @@
-// options - market status
+// Options - Market Status
 // https://polygon.io/docs/options/get_v1_marketstatus_now
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-market-status/main.go
+++ b/rest/example/options-market-status/main.go
@@ -1,0 +1,28 @@
+// options - market status
+// https://polygon.io/docs/options/get_v1_marketstatus_now
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// make request
+	res, err := c.GetMarketStatus(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-previous-close/main.go
+++ b/rest/example/options-previous-close/main.go
@@ -1,4 +1,4 @@
-// options - Previous Close
+// Options - Previous Close
 // https://polygon.io/docs/options/get_v2_aggs_ticker__optionsticker__prev
 // https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
 package main

--- a/rest/example/options-previous-close/main.go
+++ b/rest/example/options-previous-close/main.go
@@ -1,0 +1,34 @@
+// options - Previous Close
+// https://polygon.io/docs/options/get_v2_aggs_ticker__optionsticker__prev
+// https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetPreviousCloseAggParams{
+		Ticker: "O:SPY251219C00650000",
+	}.WithAdjusted(true)
+
+	// make request
+	res, err := c.GetPreviousCloseAgg(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-quotes/main.go
+++ b/rest/example/options-quotes/main.go
@@ -1,0 +1,36 @@
+// options - Quotes
+// https://polygon.io/docs/options/get_v3_quotes__optionsticker
+// https://github.com/polygon-io/client-go/blob/master/rest/quotes.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListQuotesParams{
+		Ticker: "O:SPY241220P00720000",
+	}.WithLimit(50000).WithOrder(models.Asc)
+
+	// make request
+	iter := c.ListQuotes(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/options-quotes/main.go
+++ b/rest/example/options-quotes/main.go
@@ -1,4 +1,4 @@
-// options - Quotes
+// Options - Quotes
 // https://polygon.io/docs/options/get_v3_quotes__optionsticker
 // https://github.com/polygon-io/client-go/blob/master/rest/quotes.go
 package main

--- a/rest/example/options-snapshots-option-contract/main.go
+++ b/rest/example/options-snapshots-option-contract/main.go
@@ -1,0 +1,35 @@
+// options - option contract
+// https://polygon.io/docs/options/get_v3_snapshot_options__underlyingasset___optioncontract
+// https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetOptionContractSnapshotParams{
+		UnderlyingAsset: "AAPL",
+		OptionContract:  "O:AAPL230616C00150000",
+	}
+
+	// make request
+	res, err := c.GetOptionContractSnapshot(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-snapshots-option-contract/main.go
+++ b/rest/example/options-snapshots-option-contract/main.go
@@ -1,4 +1,4 @@
-// options - option contract
+// Options - Option Contract
 // https://polygon.io/docs/options/get_v3_snapshot_options__underlyingasset___optioncontract
 // https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
 package main

--- a/rest/example/options-snapshots-options-chain/main.go
+++ b/rest/example/options-snapshots-options-chain/main.go
@@ -1,4 +1,4 @@
-// options - options chain
+// Options - Options Chain
 // https://polygon.io/docs/options/get_v3_snapshot_options__underlyingasset
 // https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
 package main

--- a/rest/example/options-snapshots-options-chain/main.go
+++ b/rest/example/options-snapshots-options-chain/main.go
@@ -1,0 +1,36 @@
+// options - options chain
+// https://polygon.io/docs/options/get_v3_snapshot_options__underlyingasset
+// https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.ListOptionsChainParams{
+		UnderlyingAsset: "AAPL",
+	}
+
+	// make request
+	iter := c.ListOptionsChainSnapshot(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/options-technical-indicators-ema/main.go
+++ b/rest/example/options-technical-indicators-ema/main.go
@@ -1,0 +1,34 @@
+// options - Exponential Moving Average (EMA)
+// https://polygon.io/docs/options/get_v1_indicators_ema__optionsticker
+// https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetEMAParams{
+		Ticker: "O:SPY241220P00720000",
+	}
+
+	// make request
+	res, err := c.GetEMA(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-technical-indicators-ema/main.go
+++ b/rest/example/options-technical-indicators-ema/main.go
@@ -1,4 +1,4 @@
-// options - Exponential Moving Average (EMA)
+// Options - Exponential Moving Average (EMA)
 // https://polygon.io/docs/options/get_v1_indicators_ema__optionsticker
 // https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
 package main

--- a/rest/example/options-technical-indicators-macd/main.go
+++ b/rest/example/options-technical-indicators-macd/main.go
@@ -1,0 +1,34 @@
+// options - Moving Average Convergence/Divergence (MACD)
+// https://polygon.io/docs/options/get_v1_indicators_macd__optionsticker
+// https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetMACDParams{
+		Ticker: "O:SPY241220P00720000",
+	}
+
+	// make request
+	res, err := c.GetMACD(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-technical-indicators-macd/main.go
+++ b/rest/example/options-technical-indicators-macd/main.go
@@ -1,4 +1,4 @@
-// options - Moving Average Convergence/Divergence (MACD)
+// Options - Moving Average Convergence/Divergence (MACD)
 // https://polygon.io/docs/options/get_v1_indicators_macd__optionsticker
 // https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
 package main

--- a/rest/example/options-technical-indicators-rsi/main.go
+++ b/rest/example/options-technical-indicators-rsi/main.go
@@ -1,4 +1,4 @@
-// options - Relative Strength Index (RSI)
+// Options - Relative Strength Index (RSI)
 // https://polygon.io/docs/options/get_v1_indicators_rsi__optionsticker
 // https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
 package main

--- a/rest/example/options-technical-indicators-rsi/main.go
+++ b/rest/example/options-technical-indicators-rsi/main.go
@@ -1,0 +1,34 @@
+// options - Relative Strength Index (RSI)
+// https://polygon.io/docs/options/get_v1_indicators_rsi__optionsticker
+// https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetRSIParams{
+		Ticker: "O:SPY241220P00720000",
+	}
+
+	// make request
+	res, err := c.GetRSI(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-technical-indicators-sma/main.go
+++ b/rest/example/options-technical-indicators-sma/main.go
@@ -1,4 +1,4 @@
-// options - Simple Moving Average (SMA)
+// Options - Simple Moving Average (SMA)
 // https://polygon.io/docs/options/get_v1_indicators_sma__optionsticker
 // https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
 package main

--- a/rest/example/options-technical-indicators-sma/main.go
+++ b/rest/example/options-technical-indicators-sma/main.go
@@ -1,0 +1,34 @@
+// options - Simple Moving Average (SMA)
+// https://polygon.io/docs/options/get_v1_indicators_sma__optionsticker
+// https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetSMAParams{
+		Ticker: "O:SPY241220P00720000",
+	}
+
+	// make request
+	res, err := c.GetSMA(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-ticker-details/main.go
+++ b/rest/example/options-ticker-details/main.go
@@ -1,0 +1,35 @@
+// options - ticker details v3
+// https://polygon.io/docs/options/get_v3_reference_tickers__ticker
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetTickerDetailsParams{
+		Ticker:     "TSLA",
+	}.WithDate(models.Date(time.Date(2023, 3, 9, 0, 0, 0, 0, time.UTC)))
+
+	// make request
+	res, err := c.GetTickerDetails(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/options-ticker-details/main.go
+++ b/rest/example/options-ticker-details/main.go
@@ -1,4 +1,4 @@
-// options - ticker details v3
+// Options - Ticker Details v3
 // https://polygon.io/docs/options/get_v3_reference_tickers__ticker
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-ticker-news/main.go
+++ b/rest/example/options-ticker-news/main.go
@@ -1,4 +1,4 @@
-// options - ticker news
+// Options - Ticker News
 // https://polygon.io/docs/options/get_v3_reference_tickers__ticker
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-ticker-news/main.go
+++ b/rest/example/options-ticker-news/main.go
@@ -1,0 +1,40 @@
+// options - ticker news
+// https://polygon.io/docs/options/get_v3_reference_tickers__ticker
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListTickerNewsParams{}.
+		WithTicker(models.LTE, "AAPL").
+		WithPublishedUTC(models.LT, models.Millis(time.Date(2023, 3, 9, 0, 0, 0, 0, time.UTC))).
+		WithSort(models.PublishedUTC).
+		WithOrder(models.Asc).
+		WithLimit(1000)
+
+	// make request
+	iter := c.ListTickerNews(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/options-tickers/main.go
+++ b/rest/example/options-tickers/main.go
@@ -1,0 +1,41 @@
+// options - tickers
+// https://polygon.io/docs/options/get_v3_reference_tickers
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListTickersParams{}.
+		WithType("CS").
+		WithMarket(models.AssetStocks).
+		WithExchange("XNAS").
+		WithActive(true).
+		WithSort(models.TickerSymbol).
+		WithOrder(models.Asc).
+		WithLimit(1000)
+
+	// make request
+	iter := c.ListTickers(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/options-tickers/main.go
+++ b/rest/example/options-tickers/main.go
@@ -1,4 +1,4 @@
-// options - tickers
+// Options - Tickers
 // https://polygon.io/docs/options/get_v3_reference_tickers
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/options-trades/main.go
+++ b/rest/example/options-trades/main.go
@@ -1,0 +1,36 @@
+// options - Trades
+// https://polygon.io/docs/options/get_v3_trades__optionsticker
+// https://github.com/polygon-io/client-go/blob/master/rest/trades.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListTradesParams{
+		Ticker: "O:TSLA210903C00700000",
+	}.WithLimit(50000).WithOrder(models.Asc)
+
+	// make request
+	iter := c.ListTrades(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/options-trades/main.go
+++ b/rest/example/options-trades/main.go
@@ -1,4 +1,4 @@
-// options - Trades
+// Options - Trades
 // https://polygon.io/docs/options/get_v3_trades__optionsticker
 // https://github.com/polygon-io/client-go/blob/master/rest/trades.go
 package main

--- a/rest/example/stocks-aggregates-bars/main.go
+++ b/rest/example/stocks-aggregates-bars/main.go
@@ -1,4 +1,4 @@
-// stocks - aggregates (bars)
+// Stocks - Aggregates (Bars)
 // https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to
 // https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
 package main
@@ -19,21 +19,23 @@ func main() {
 	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
 
 	// set params
-	params := models.GetAggsParams{
+	params := models.ListAggsParams{
 		Ticker:     "AAPL",
 		Multiplier: 1,
 		Timespan:   "day",
 		From:       models.Millis(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
 		To:         models.Millis(time.Date(2023, 3, 9, 0, 0, 0, 0, time.UTC)),
-	}.WithOrder(models.Desc).WithLimit(2).WithAdjusted(true)
+	}.WithOrder(models.Desc).WithLimit(50000).WithAdjusted(true)
 
 	// make request
-	res, err := c.GetAggs(context.Background(), params)
-	if err != nil {
-		log.Fatal(err)
-	}
+	iter := c.ListAggs(context.Background(), params)
 
 	// do something with the result
-	log.Print(res) 
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
 
 }

--- a/rest/example/stocks-aggregates-bars/main.go
+++ b/rest/example/stocks-aggregates-bars/main.go
@@ -1,0 +1,39 @@
+// stocks - aggregates (bars)
+// https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to
+// https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetAggsParams{
+		Ticker:     "AAPL",
+		Multiplier: 1,
+		Timespan:   "day",
+		From:       models.Millis(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+		To:         models.Millis(time.Date(2023, 3, 9, 0, 0, 0, 0, time.UTC)),
+	}.WithOrder(models.Desc).WithLimit(2).WithAdjusted(true)
+
+	// make request
+	res, err := c.GetAggs(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-conditions/main.go
+++ b/rest/example/stocks-conditions/main.go
@@ -1,4 +1,4 @@
-// stocks - conditions
+// Stocks - Conditions
 // https://polygon.io/docs/stocks/get_v3_reference_conditions
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-conditions/main.go
+++ b/rest/example/stocks-conditions/main.go
@@ -1,0 +1,37 @@
+// stocks - conditions
+// https://polygon.io/docs/stocks/get_v3_reference_conditions
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListConditionsParams{}.
+		WithAssetClass(models.AssetStocks).
+		WithDataType(models.DataTrade).
+		WithLimit(1000)
+
+	// make request
+	iter := c.ListConditions(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/stocks-daily-open-close/main.go
+++ b/rest/example/stocks-daily-open-close/main.go
@@ -1,0 +1,36 @@
+// stocks - Daily Open/Close
+// https://polygon.io/docs/stocks/get_v1_open-close__stocksticker___date
+// https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetDailyOpenCloseAggParams{
+		Ticker: "AAPL",
+		Date:   models.Date(time.Date(2023, 3, 8, 0, 0, 0, 0, time.Local)),
+	}.WithAdjusted(true)
+
+	// make request
+	res, err := c.GetDailyOpenCloseAgg(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-daily-open-close/main.go
+++ b/rest/example/stocks-daily-open-close/main.go
@@ -1,4 +1,4 @@
-// stocks - Daily Open/Close
+// Stocks - Daily Open/Close
 // https://polygon.io/docs/stocks/get_v1_open-close__stocksticker___date
 // https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
 package main

--- a/rest/example/stocks-dividends/main.go
+++ b/rest/example/stocks-dividends/main.go
@@ -1,4 +1,4 @@
-// stocks - dividends v3
+// Stocks - Dividends v3
 // https://polygon.io/docs/stocks/get_v3_reference_dividends
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-dividends/main.go
+++ b/rest/example/stocks-dividends/main.go
@@ -1,0 +1,38 @@
+// stocks - dividends v3
+// https://polygon.io/docs/stocks/get_v3_reference_dividends
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListDividendsParams{}.
+		WithTicker(models.EQ, "MSFT").
+		WithDividendType(models.DividendCD).
+		WithLimit(1000).
+		WithOrder(models.Desc)
+
+	// make request
+	iter := c.ListDividends(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/stocks-exchanges/main.go
+++ b/rest/example/stocks-exchanges/main.go
@@ -1,4 +1,4 @@
-// stocks - exchanges
+// Stocks - Exchanges
 // https://polygon.io/docs/stocks/get_v3_reference_exchanges
 package main
 

--- a/rest/example/stocks-exchanges/main.go
+++ b/rest/example/stocks-exchanges/main.go
@@ -1,0 +1,31 @@
+// stocks - exchanges
+// https://polygon.io/docs/stocks/get_v3_reference_exchanges
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetExchangesParams{}
+
+	// make request
+	res, err := c.GetExchanges(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-grouped-daily-bars/main.go
+++ b/rest/example/stocks-grouped-daily-bars/main.go
@@ -1,0 +1,37 @@
+// stocks - Grouped Daily (Bars)
+// https://polygon.io/docs/stocks/get_v2_aggs_grouped_locale_us_market_stocks__date
+// https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetGroupedDailyAggsParams{
+		Locale:     models.US,
+		MarketType: models.Stocks,
+		Date:       models.Date(time.Date(2023, 3, 8, 0, 0, 0, 0, time.Local)),
+	}.WithAdjusted(true)
+
+	// make request
+	res, err := c.GetGroupedDailyAggs(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-grouped-daily-bars/main.go
+++ b/rest/example/stocks-grouped-daily-bars/main.go
@@ -1,4 +1,4 @@
-// stocks - Grouped Daily (Bars)
+// Stocks - Grouped Daily (Bars)
 // https://polygon.io/docs/stocks/get_v2_aggs_grouped_locale_us_market_stocks__date
 // https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
 package main

--- a/rest/example/stocks-last-quote/main.go
+++ b/rest/example/stocks-last-quote/main.go
@@ -1,0 +1,33 @@
+// stocks - get last nbbo quote
+// https://polygon.io/docs/stocks/get_v2_last_nbbo__stocksticker
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetLastQuoteParams{
+		Ticker:     "AAPL",
+	}
+
+	// make request
+	res, err := c.GetLastQuote(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-last-quote/main.go
+++ b/rest/example/stocks-last-quote/main.go
@@ -1,5 +1,6 @@
-// stocks - get last nbbo quote
+// Stocks - Last Quote (NBBO)
 // https://polygon.io/docs/stocks/get_v2_last_nbbo__stocksticker
+// https://github.com/polygon-io/client-go/blob/master/rest/quotes.go
 package main
 
 import (

--- a/rest/example/stocks-last-trade/main.go
+++ b/rest/example/stocks-last-trade/main.go
@@ -1,4 +1,4 @@
-// stocks - get last trade
+// Stocks - Last Trade
 // https://polygon.io/docs/stocks/get_v2_last_trade__stocksticker
 // https://github.com/polygon-io/client-go/blob/master/rest/trades.go
 package main

--- a/rest/example/stocks-last-trade/main.go
+++ b/rest/example/stocks-last-trade/main.go
@@ -1,0 +1,34 @@
+// stocks - get last trade
+// https://polygon.io/docs/stocks/get_v2_last_trade__stocksticker
+// https://github.com/polygon-io/client-go/blob/master/rest/trades.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetLastTradeParams{
+		Ticker:     "AAPL",
+	}
+
+	// make request
+	res, err := c.GetLastTrade(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-market-holidays/main.go
+++ b/rest/example/stocks-market-holidays/main.go
@@ -1,4 +1,4 @@
-// stocks - market holidays
+// Stocks - Market Holidays
 // https://polygon.io/docs/stocks/get_v1_marketstatus_upcoming
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-market-holidays/main.go
+++ b/rest/example/stocks-market-holidays/main.go
@@ -1,0 +1,28 @@
+// stocks - market holidays
+// https://polygon.io/docs/stocks/get_v1_marketstatus_upcoming
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// make request
+	res, err := c.GetMarketHolidays(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-market-status/main.go
+++ b/rest/example/stocks-market-status/main.go
@@ -1,0 +1,28 @@
+// stocks - market status
+// https://polygon.io/docs/stocks/get_v1_marketstatus_now
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// make request
+	res, err := c.GetMarketStatus(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-market-status/main.go
+++ b/rest/example/stocks-market-status/main.go
@@ -1,4 +1,4 @@
-// stocks - market status
+// Stocks - Market Status
 // https://polygon.io/docs/stocks/get_v1_marketstatus_now
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-previous-close/main.go
+++ b/rest/example/stocks-previous-close/main.go
@@ -1,0 +1,34 @@
+// stocks - Previous Close
+// https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__prev
+// https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetPreviousCloseAggParams{
+		Ticker: "AAPL",
+	}.WithAdjusted(true)
+
+	// make request
+	res, err := c.GetPreviousCloseAgg(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-previous-close/main.go
+++ b/rest/example/stocks-previous-close/main.go
@@ -1,4 +1,4 @@
-// stocks - Previous Close
+// Stocks - Previous Close
 // https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__prev
 // https://github.com/polygon-io/client-go/blob/master/rest/aggs.go
 package main

--- a/rest/example/stocks-quotes/main.go
+++ b/rest/example/stocks-quotes/main.go
@@ -1,0 +1,40 @@
+// stocks - Quotes (NBBO)
+// https://polygon.io/docs/stocks/get_v3_quotes__stockticker
+// https://github.com/polygon-io/client-go/blob/master/rest/quotes.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListQuotesParams{
+		Ticker: "AAPL",
+	}.WithTimestamp(models.EQ, models.Nanos(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))).
+		WithSort(models.Timestamp).
+		WithOrder(models.Asc).
+		WithLimit(50000)
+
+	// make request
+	iter := c.ListQuotes(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/stocks-quotes/main.go
+++ b/rest/example/stocks-quotes/main.go
@@ -1,4 +1,4 @@
-// stocks - Quotes (NBBO)
+// Stocks - Quotes (NBBO)
 // https://polygon.io/docs/stocks/get_v3_quotes__stockticker
 // https://github.com/polygon-io/client-go/blob/master/rest/quotes.go
 package main

--- a/rest/example/stocks-snapshots-all/main.go
+++ b/rest/example/stocks-snapshots-all/main.go
@@ -1,0 +1,35 @@
+// stocks - snapshot all tickers
+// https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers
+// https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetAllTickersSnapshotParams{
+		Locale:     models.US,
+		MarketType: models.Stocks,
+	}.WithTickers("AAPL,MSFT")
+
+	// make request
+	res, err := c.GetAllTickersSnapshot(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-snapshots-all/main.go
+++ b/rest/example/stocks-snapshots-all/main.go
@@ -1,4 +1,4 @@
-// stocks - snapshot all tickers
+// Stocks - Snapshot All Tickers
 // https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers
 // https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
 package main

--- a/rest/example/stocks-snapshots-gainers-losers/main.go
+++ b/rest/example/stocks-snapshots-gainers-losers/main.go
@@ -1,4 +1,4 @@
-// stocks - snapshot gainers/losers
+// Stocks - Snapshot Gainers/Losers
 // https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks__direction
 // https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
 package main

--- a/rest/example/stocks-snapshots-gainers-losers/main.go
+++ b/rest/example/stocks-snapshots-gainers-losers/main.go
@@ -1,0 +1,36 @@
+// stocks - snapshot gainers/losers
+// https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks__direction
+// https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetGainersLosersSnapshotParams{
+		Locale:     "us",
+		MarketType: "stocks",
+		Direction:  "gainers", // or "losers"
+	}
+
+	// make request
+	res, err := c.GetGainersLosersSnapshot(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-snapshots-ticker/main.go
+++ b/rest/example/stocks-snapshots-ticker/main.go
@@ -1,0 +1,36 @@
+// stocks - snapshot ticker
+// https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers__stocksticker
+// https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetTickerSnapshotParams{
+		Ticker:     "AAPL",
+		Locale:     "us",
+		MarketType: "stocks",
+	}
+
+	// make request
+	res, err := c.GetTickerSnapshot(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-snapshots-ticker/main.go
+++ b/rest/example/stocks-snapshots-ticker/main.go
@@ -1,4 +1,4 @@
-// stocks - snapshot ticker
+// Stocks - Snapshot Ticker
 // https://polygon.io/docs/stocks/get_v2_snapshot_locale_us_markets_stocks_tickers__stocksticker
 // https://github.com/polygon-io/client-go/blob/master/rest/snapshot.go
 package main

--- a/rest/example/stocks-stock-financials/main.go
+++ b/rest/example/stocks-stock-financials/main.go
@@ -1,4 +1,4 @@
-// stocks - stock financials vX
+// Stocks - Stock Financials vX
 // https://polygon.io/docs/stocks/get_vx_reference_financials
 // https://github.com/polygon-io/client-go/blob/master/rest/vx.go
 package main

--- a/rest/example/stocks-stock-financials/main.go
+++ b/rest/example/stocks-stock-financials/main.go
@@ -1,0 +1,35 @@
+// stocks - stock financials vX
+// https://polygon.io/docs/stocks/get_vx_reference_financials
+// https://github.com/polygon-io/client-go/blob/master/rest/vx.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListStockFinancialsParams{}.
+		WithTicker("AAPL")
+
+	// make request
+	iter := c.VX.ListStockFinancials(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/stocks-stock-splits/main.go
+++ b/rest/example/stocks-stock-splits/main.go
@@ -1,0 +1,41 @@
+// stocks - stock splits v3
+// https://polygon.io/docs/stocks/get_v3_reference_splits
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListSplitsParams{}.
+		WithTicker(models.EQ, "AAPL").
+		WithExecutionDate(models.EQ, models.Date(time.Date(2020, 8, 31, 0, 0, 0, 0, time.UTC))).
+		WithReverseSplit(false).
+		WithSort(models.TickerSymbol).
+		WithOrder(models.Asc).
+		WithLimit(1000)
+
+	// make request
+	iter := c.ListSplits(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/stocks-stock-splits/main.go
+++ b/rest/example/stocks-stock-splits/main.go
@@ -1,4 +1,4 @@
-// stocks - stock splits v3
+// Stocks - Stock Splits v3
 // https://polygon.io/docs/stocks/get_v3_reference_splits
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-technical-indicators-ema/main.go
+++ b/rest/example/stocks-technical-indicators-ema/main.go
@@ -1,0 +1,34 @@
+// stocks - Exponential Moving Average (EMA)
+// https://polygon.io/docs/stocks/get_v1_indicators_ema__stockticker
+// https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetEMAParams{
+		Ticker: "AAPL",
+	}
+
+	// make request
+	res, err := c.GetEMA(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-technical-indicators-ema/main.go
+++ b/rest/example/stocks-technical-indicators-ema/main.go
@@ -1,4 +1,4 @@
-// stocks - Exponential Moving Average (EMA)
+// Stocks - Exponential Moving Average (EMA)
 // https://polygon.io/docs/stocks/get_v1_indicators_ema__stockticker
 // https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
 package main

--- a/rest/example/stocks-technical-indicators-macd/main.go
+++ b/rest/example/stocks-technical-indicators-macd/main.go
@@ -1,4 +1,4 @@
-// stocks - Moving Average Convergence/Divergence (MACD)
+// Stocks - Moving Average Convergence/Divergence (MACD)
 // https://polygon.io/docs/stocks/get_v1_indicators_macd__stockticker
 // https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
 package main

--- a/rest/example/stocks-technical-indicators-macd/main.go
+++ b/rest/example/stocks-technical-indicators-macd/main.go
@@ -1,0 +1,37 @@
+// stocks - Moving Average Convergence/Divergence (MACD)
+// https://polygon.io/docs/stocks/get_v1_indicators_macd__stockticker
+// https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetMACDParams{
+		Ticker: "AAPL",
+	}.WithShortWindow(12).
+		WithLongWindow(26).
+		WithSignalWindow(9).
+		WithOrder(models.Desc)
+
+	// make request
+	res, err := c.GetMACD(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-technical-indicators-rsi/main.go
+++ b/rest/example/stocks-technical-indicators-rsi/main.go
@@ -1,4 +1,4 @@
-// stocks - Relative Strength Index (RSI)
+// Stocks - Relative Strength Index (RSI)
 // https://polygon.io/docs/stocks/get_v1_indicators_rsi__stockticker
 // https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
 package main

--- a/rest/example/stocks-technical-indicators-rsi/main.go
+++ b/rest/example/stocks-technical-indicators-rsi/main.go
@@ -1,0 +1,34 @@
+// stocks - Relative Strength Index (RSI)
+// https://polygon.io/docs/stocks/get_v1_indicators_rsi__stockticker
+// https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetRSIParams{
+		Ticker: "AAPL",
+	}
+
+	// make request
+	res, err := c.GetRSI(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-technical-indicators-sma/main.go
+++ b/rest/example/stocks-technical-indicators-sma/main.go
@@ -1,4 +1,4 @@
-// stocks - Simple Moving Average (SMA)
+// Stocks - Simple Moving Average (SMA)
 // https://polygon.io/docs/stocks/get_v1_indicators_sma__stockticker
 // https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
 package main

--- a/rest/example/stocks-technical-indicators-sma/main.go
+++ b/rest/example/stocks-technical-indicators-sma/main.go
@@ -1,0 +1,34 @@
+// stocks - Simple Moving Average (SMA)
+// https://polygon.io/docs/stocks/get_v1_indicators_sma__stockticker
+// https://github.com/polygon-io/client-go/blob/master/rest/indicators.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetSMAParams{
+		Ticker: "AAPL",
+	}
+
+	// make request
+	res, err := c.GetSMA(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-ticker-details/main.go
+++ b/rest/example/stocks-ticker-details/main.go
@@ -1,0 +1,35 @@
+// stocks - ticker details v3
+// https://polygon.io/docs/stocks/get_v3_reference_tickers__ticker
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetTickerDetailsParams{
+		Ticker:     "AAPL",
+	}.WithDate(models.Date(time.Date(2023, 3, 9, 0, 0, 0, 0, time.UTC)))
+
+	// make request
+	res, err := c.GetTickerDetails(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-ticker-details/main.go
+++ b/rest/example/stocks-ticker-details/main.go
@@ -1,4 +1,4 @@
-// stocks - ticker details v3
+// Stocks - Ticker Details v3
 // https://polygon.io/docs/stocks/get_v3_reference_tickers__ticker
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-ticker-events/main.go
+++ b/rest/example/stocks-ticker-events/main.go
@@ -1,0 +1,34 @@
+// stocks - ticker events
+// https://polygon.io/docs/stocks/get_vx_reference_tickers__id__events
+// https://github.com/polygon-io/client-go/blob/master/rest/vx.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := &models.GetTickerEventsParams{
+		ID: "TSLA",
+	}
+
+	// make request
+	res, err := c.VX.GetTickerEvents(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-ticker-events/main.go
+++ b/rest/example/stocks-ticker-events/main.go
@@ -1,4 +1,4 @@
-// stocks - ticker events
+// Stocks - Ticker Events
 // https://polygon.io/docs/stocks/get_vx_reference_tickers__id__events
 // https://github.com/polygon-io/client-go/blob/master/rest/vx.go
 package main

--- a/rest/example/stocks-ticker-news/main.go
+++ b/rest/example/stocks-ticker-news/main.go
@@ -1,4 +1,4 @@
-// stocks - ticker news
+// Stocks - Ticker News
 // https://polygon.io/docs/stocks/get_v2_reference_news
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-ticker-news/main.go
+++ b/rest/example/stocks-ticker-news/main.go
@@ -1,0 +1,40 @@
+// stocks - ticker news
+// https://polygon.io/docs/stocks/get_v2_reference_news
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"time"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListTickerNewsParams{}.
+		WithTicker(models.LTE, "AAPL").
+		WithPublishedUTC(models.LT, models.Millis(time.Date(2023, 3, 9, 0, 0, 0, 0, time.UTC))).
+		WithSort(models.PublishedUTC).
+		WithOrder(models.Asc).
+		WithLimit(1000)
+
+	// make request
+	iter := c.ListTickerNews(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/stocks-ticker-types/main.go
+++ b/rest/example/stocks-ticker-types/main.go
@@ -1,0 +1,34 @@
+// stocks - ticker types
+// https://polygon.io/docs/stocks/get_v3_reference_tickers_types
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.GetTickerTypesParams{}.
+		WithAssetClass("stocks").
+		WithLocale(models.US)
+
+	// make request
+	res, err := c.GetTickerTypes(context.Background(), params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// do something with the result
+	log.Print(res) 
+
+}

--- a/rest/example/stocks-ticker-types/main.go
+++ b/rest/example/stocks-ticker-types/main.go
@@ -1,4 +1,4 @@
-// stocks - ticker types
+// Stocks - Ticker Types
 // https://polygon.io/docs/stocks/get_v3_reference_tickers_types
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-tickers/main.go
+++ b/rest/example/stocks-tickers/main.go
@@ -1,4 +1,4 @@
-// stocks - tickers
+// Stocks - Tickers
 // https://polygon.io/docs/stocks/get_v3_reference_tickers
 // https://github.com/polygon-io/client-go/blob/master/rest/reference.go
 package main

--- a/rest/example/stocks-tickers/main.go
+++ b/rest/example/stocks-tickers/main.go
@@ -1,0 +1,41 @@
+// stocks - tickers
+// https://polygon.io/docs/stocks/get_v3_reference_tickers
+// https://github.com/polygon-io/client-go/blob/master/rest/reference.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListTickersParams{}.
+		WithType("CS").
+		WithMarket(models.AssetStocks).
+		WithExchange("XNAS").
+		WithActive(true).
+		WithSort(models.TickerSymbol).
+		WithOrder(models.Asc).
+		WithLimit(1000)
+
+	// make request
+	iter := c.ListTickers(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/stocks-trades/main.go
+++ b/rest/example/stocks-trades/main.go
@@ -1,0 +1,36 @@
+// stocks - Trades
+// https://polygon.io/docs/stocks/get_v3_trades__stockticker
+// https://github.com/polygon-io/client-go/blob/master/rest/trades.go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+
+	// init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// set params
+	params := models.ListTradesParams{
+		Ticker: "IBIO",
+	}.WithDay(2023, 2, 1).WithLimit(50000).WithOrder(models.Asc)
+
+	// make request
+	iter := c.ListTrades(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Print(iter.Item()) 
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+
+}

--- a/rest/example/stocks-trades/main.go
+++ b/rest/example/stocks-trades/main.go
@@ -1,4 +1,4 @@
-// stocks - Trades
+// Stocks - Trades
 // https://polygon.io/docs/stocks/get_v3_trades__stockticker
 // https://github.com/polygon-io/client-go/blob/master/rest/trades.go
 package main


### PR DESCRIPTION
Added rest examples for all stocks and options API endpoints. These are self contained code snippets that show off each capability and can be used as a quick starting point. 