### PR TITLE
Force gzip encoding for faster response and reduced bandwidth usage

### DIFF
--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -47,6 +47,7 @@ func newClient(apiKey string, hc *http.Client) Client {
 	c.SetRetryCount(DefaultRetryCount)
 	c.SetTimeout(10 * time.Second)
 	c.SetHeader("User-Agent", fmt.Sprintf("Polygon.io GoClient/%v", clientVersion))
+	c.SetHeader("Accept-Encoding", "gzip")
 
 	return Client{
 		HTTP:    c,


### PR DESCRIPTION
Enables gzip encoding for all HTTP requests, by adding the "Accept-Encoding: gzip" header to the request. Gzip encoding compresses the response body before sending it to the client, which reduces the size of the response and saves bandwidth.

`github.com/go-resty/resty` supports gzip encoding out of the box. However, by default, rusty does not request gzip encoded content but it will automatically decode the gzip response if the server returns a compressed response. So, we are explicitly requesting gzip encoding via the request headers, by adding setting the Accept-Encoding header to gzip.

By enabling gzip encoding, we expect to see faster download times and reduced bandwidth usage for our users.

Server response headers without gzip:

```
Response headers:
Vary: [Accept-Encoding]
X-Request-Id: [b3807918f8f4f912459cdd3934fc4e76]
Strict-Transport-Security: [max-age=15724800; includeSubDomains]
Server: [nginx/1.19.2]
Date: [Mon, 20 Mar 2023 23:03:31 GMT]
Content-Type: [application/json]
```

Server response headers with gzip:

```
Response headers:
Content-Type: [application/json]
Content-Length: [1637]
Content-Encoding: [gzip]
Vary: [Accept-Encoding]
X-Request-Id: [36bc3c326738876e4229f6b262ef717d]
Strict-Transport-Security: [max-age=15724800; includeSubDomains]
Server: [nginx/1.19.2]
Date: [Mon, 20 Mar 2023 23:02:45 GMT]
```

Client returns same results in both case.