### PR TITLE
Add Tests to get Coverage Over 80%

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -21,9 +21,7 @@ jobs:
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: go-test
         run: |
-          go test -v ./... -covermode=count -coverprofile=coverage.out.temp
-          cat coverage.out.temp | grep -v "/example" > coverage.out
-          rm coverage.out.temp
+          go test -v ./... -covermode=count -coverprofile=coverage.out
           go tool cover -func=coverage.out -o=coverage.out
       - name: go-coverage-badge  # Pass the `coverage.out` output to this action
         uses: tj-actions/coverage-badge-go@v2

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -21,7 +21,9 @@ jobs:
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: go-test
         run: |
-          go test -v ./... -covermode=count -coverprofile=coverage.out
+          go test -v ./... -covermode=count -coverprofile=coverage.out.temp
+          cat coverage.out.temp | grep -v "/example" > coverage.out
+          rm coverage.out.temp
           go tool cover -func=coverage.out -o=coverage.out
       - name: go-coverage-badge  # Pass the `coverage.out` output to this action
         uses: tj-actions/coverage-badge-go@v2

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool
 *.out
+*.out.temp
 
 # Dependency directories
 vendor/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-40.7%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-80.5%25-brightgreen)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/rest/models/aggs_test.go
+++ b/rest/models/aggs_test.go
@@ -1,0 +1,78 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListAggsParamsMethods(t *testing.T) {
+	params := models.ListAggsParams{}
+	assert.Nil(t, params.Adjusted)
+	assert.Nil(t, params.Order)
+	assert.Nil(t, params.Limit)
+
+	params = *params.WithAdjusted(true)
+	assert.NotNil(t, params.Adjusted)
+	assert.Equal(t, true, *params.Adjusted)
+
+	params = *params.WithOrder(models.Asc)
+	assert.NotNil(t, params.Order)
+	assert.Equal(t, models.Asc, *params.Order)
+
+	params = *params.WithLimit(50)
+	assert.NotNil(t, params.Limit)
+	assert.Equal(t, 50, *params.Limit)
+}
+
+func TestGetAggsParamsMethods(t *testing.T) {
+	params := models.GetAggsParams{}
+	assert.Nil(t, params.Adjusted)
+	assert.Nil(t, params.Order)
+	assert.Nil(t, params.Limit)
+
+	params = *params.WithAdjusted(true)
+	assert.NotNil(t, params.Adjusted)
+	assert.Equal(t, true, *params.Adjusted)
+
+	params = *params.WithOrder(models.Asc)
+	assert.NotNil(t, params.Order)
+	assert.Equal(t, models.Asc, *params.Order)
+
+	params = *params.WithLimit(50)
+	assert.NotNil(t, params.Limit)
+	assert.Equal(t, 50, *params.Limit)
+}
+
+func TestGetGroupedDailyAggsParamsMethods(t *testing.T) {
+	params := models.GetGroupedDailyAggsParams{}
+	assert.Nil(t, params.Adjusted)
+	assert.Nil(t, params.IncludeOTC)
+
+	params = *params.WithAdjusted(true)
+	assert.NotNil(t, params.Adjusted)
+	assert.Equal(t, true, *params.Adjusted)
+
+	params = *params.WithIncludeOTC(true)
+	assert.NotNil(t, params.IncludeOTC)
+	assert.Equal(t, true, *params.IncludeOTC)
+}
+
+func TestGetDailyOpenCloseAggParamsMethods(t *testing.T) {
+	params := models.GetDailyOpenCloseAggParams{}
+	assert.Nil(t, params.Adjusted)
+
+	params = *params.WithAdjusted(true)
+	assert.NotNil(t, params.Adjusted)
+	assert.Equal(t, true, *params.Adjusted)
+}
+
+func TestGetPreviousCloseAggParamsMethods(t *testing.T) {
+	params := models.GetPreviousCloseAggParams{}
+	assert.Nil(t, params.Adjusted)
+
+	params = *params.WithAdjusted(true)
+	assert.NotNil(t, params.Adjusted)
+	assert.Equal(t, true, *params.Adjusted)
+}

--- a/rest/models/conditions_test.go
+++ b/rest/models/conditions_test.go
@@ -1,0 +1,50 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/polygon-io/client-go/rest/models"
+)
+
+func TestListConditionsParams(t *testing.T) {
+	var (
+		assetClass AssetClass = "Equity"
+		dataType   DataType   = "EndOfDay"
+		id         int64      = 1
+		sip        SIP        = "CTA"
+		order      Order      = "asc"
+		limit      int        = 20
+		sort       Sort       = "name"
+	)
+
+	params := ListConditionsParams{}
+	paramsWithAssetClass := params.WithAssetClass(assetClass)
+	assert.NotNil(t, paramsWithAssetClass.AssetClass)
+	assert.Equal(t, assetClass, *paramsWithAssetClass.AssetClass)
+
+	paramsWithDataType := params.WithDataType(dataType)
+	assert.NotNil(t, paramsWithDataType.DataType)
+	assert.Equal(t, dataType, *paramsWithDataType.DataType)
+
+	paramsWithID := params.WithID(id)
+	assert.NotNil(t, paramsWithID.ID)
+	assert.Equal(t, id, *paramsWithID.ID)
+
+	paramsWithSIP := params.WithSIP(sip)
+	assert.NotNil(t, paramsWithSIP.SIP)
+	assert.Equal(t, sip, *paramsWithSIP.SIP)
+
+	paramsWithOrder := params.WithOrder(order)
+	assert.NotNil(t, paramsWithOrder.Order)
+	assert.Equal(t, order, *paramsWithOrder.Order)
+
+	paramsWithLimit := params.WithLimit(limit)
+	assert.NotNil(t, paramsWithLimit.Limit)
+	assert.Equal(t, limit, *paramsWithLimit.Limit)
+
+	paramsWithSort := params.WithSort(sort)
+	assert.NotNil(t, paramsWithSort.Sort)
+	assert.Equal(t, sort, *paramsWithSort.Sort)
+}

--- a/rest/models/contracts_test.go
+++ b/rest/models/contracts_test.go
@@ -1,0 +1,62 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestGetOptionsContractParams(t *testing.T) {
+	params := models.GetOptionsContractParams{
+		Ticker: "TEST_TICKER",
+	}
+	assert.Equal(t, "TEST_TICKER", params.Ticker)
+	date := models.Date(time.Date(2023, 3, 23, 0, 0, 0, 0, time.Local))
+	params = *params.WithAsOf(date)
+	assert.NotNil(t, params.AsOf)
+	assert.Equal(t, &date, params.AsOf)
+}
+
+func TestListOptionsContractsParams(t *testing.T) {
+	params := models.ListOptionsContractsParams{}
+	date := models.Date(time.Date(2023, 3, 23, 0, 0, 0, 0, time.Local))
+	comparatorCases := []models.Comparator{
+		models.EQ,
+		models.LT,
+		models.LTE,
+		models.GT,
+		models.GTE,
+	}
+
+	for _, comparator := range comparatorCases {
+		params = *params.WithUnderlyingTicker(comparator, "TEST_TICKER")
+		params = *params.WithExpirationDate(comparator, date)
+		params = *params.WithStrikePrice(comparator, 100.0)
+	}
+
+	params = *params.WithContractType("TEST_CONTRACT_TYPE")
+	assert.NotNil(t, params.ContractType)
+	assert.Equal(t, "TEST_CONTRACT_TYPE", *params.ContractType)
+
+	params = *params.WithAsOf(date)
+	assert.NotNil(t, params.AsOf)
+	assert.Equal(t, &date, params.AsOf)
+
+	params = *params.WithExpired(true)
+	assert.NotNil(t, params.Expired)
+	assert.Equal(t, true, *params.Expired)
+
+	params = *params.WithSort(models.Sort("TEST_SORT"))
+	assert.NotNil(t, params.Sort)
+	assert.Equal(t, models.Sort("TEST_SORT"), *params.Sort)
+
+	params = *params.WithOrder(models.Asc)
+	assert.NotNil(t, params.Order)
+	assert.Equal(t, models.Asc, *params.Order)
+
+	params = *params.WithLimit(100)
+	assert.NotNil(t, params.Limit)
+	assert.Equal(t, 100, *params.Limit)
+}

--- a/rest/models/dividends_test.go
+++ b/rest/models/dividends_test.go
@@ -1,0 +1,39 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	models "github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListDividendsParams_WithMethods(t *testing.T) {
+	date := models.Date(time.Date(2023, 3, 23, 0, 0, 0, 0, time.Local))
+	freq := models.Annually
+	divType := models.DividendCD
+	order := models.Asc
+	limit := 25
+	sort := models.TickerSymbol
+
+	params := models.ListDividendsParams{}.
+		WithTicker(models.EQ, "AAPL").
+		WithExDividendDate(models.LT, date).
+		WithDeclarationDate(models.GTE, date).
+		WithFrequency(freq).
+		WithCashAmount(models.GT, 1.0).
+		WithDividendType(divType).
+		WithOrder(order).
+		WithLimit(limit).
+		WithSort(sort)
+
+	assert.Equal(t, "AAPL", *params.TickerEQ)
+	assert.Equal(t, date, *params.ExDividendDateLT)
+	assert.Equal(t, date, *params.DeclarationDateGTE)
+	assert.Equal(t, freq, *params.Frequency)
+	assert.Equal(t, 1.0, *params.CashAmountGT)
+	assert.Equal(t, divType, *params.DividendType)
+	assert.Equal(t, order, *params.Order)
+	assert.Equal(t, limit, *params.Limit)
+	assert.Equal(t, sort, *params.Sort)
+}

--- a/rest/models/exchanges_test.go
+++ b/rest/models/exchanges_test.go
@@ -1,0 +1,54 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetExchangesParams_WithAssetClass(t *testing.T) {
+	assetClass := models.AssetClass("test")
+	params := models.GetExchangesParams{}
+
+	updatedParams := params.WithAssetClass(assetClass)
+
+	assert.NotNil(t, updatedParams.AssetClass)
+	assert.Equal(t, assetClass, *updatedParams.AssetClass)
+}
+
+func TestGetExchangesParams_WithLocale(t *testing.T) {
+	locale := models.MarketLocale("test")
+	params := models.GetExchangesParams{}
+
+	updatedParams := params.WithLocale(locale)
+
+	assert.NotNil(t, updatedParams.Locale)
+	assert.Equal(t, locale, *updatedParams.Locale)
+}
+
+func TestExchange(t *testing.T) {
+	exchange := models.Exchange{
+		Acronym:       "TEST",
+		AssetClass:    "Equity",
+		ID:            1,
+		Locale:        "US",
+		MIC:           "XMIC",
+		Name:          "Test Exchange",
+		OperatingMIC:  "XOPM",
+		ParticipantID: "1",
+		Type:          "Stock",
+		URL:           "https://test.exchange",
+	}
+
+	assert.Equal(t, "TEST", exchange.Acronym)
+	assert.Equal(t, "Equity", exchange.AssetClass)
+	assert.Equal(t, int64(1), exchange.ID)
+	assert.Equal(t, "US", exchange.Locale)
+	assert.Equal(t, "XMIC", exchange.MIC)
+	assert.Equal(t, "Test Exchange", exchange.Name)
+	assert.Equal(t, "XOPM", exchange.OperatingMIC)
+	assert.Equal(t, "1", exchange.ParticipantID)
+	assert.Equal(t, "Stock", exchange.Type)
+	assert.Equal(t, "https://test.exchange", exchange.URL)
+}

--- a/rest/models/financials_test.go
+++ b/rest/models/financials_test.go
@@ -1,0 +1,68 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListStockFinancialsParams(t *testing.T) {
+	ticker := "AAPL"
+	cik := "0000320193"
+	companyName := "Apple Inc."
+	sic := "3674"
+	date := models.Date(time.Date(2022, 2, 2, 0, 0, 0, 0, time.Local))
+	timeframe := models.Timeframe("Q")
+	includeSources := true
+	order := models.Order("asc")
+	limit := 50
+	sort := models.Sort("period_of_report_date")
+
+	params := models.ListStockFinancialsParams{}.
+		WithTicker(ticker).
+		WithCIK(cik).
+		WithCompanyName(models.Full, companyName).
+		WithSIC(sic).
+		WithFilingDate(models.EQ, date).
+		WithPeriodOfReportDate(models.GTE, date).
+		WithTimeframe(timeframe).
+		WithIncludeSources(includeSources).
+		WithOrder(order).
+		WithLimit(limit).
+		WithSort(sort)
+
+	assert.NotNil(t, params.Ticker)
+	assert.NotNil(t, params.CIK)
+	assert.NotNil(t, params.CompanyNameFull)
+	assert.Nil(t, params.CompanyNameSearch)
+	assert.NotNil(t, params.SIC)
+	assert.NotNil(t, params.FilingDateEQ)
+	assert.Nil(t, params.FilingDateLT)
+	assert.Nil(t, params.FilingDateLTE)
+	assert.Nil(t, params.FilingDateGT)
+	assert.Nil(t, params.FilingDateGTE)
+	assert.Nil(t, params.PeriodOfReportDateEQ)
+	assert.Nil(t, params.PeriodOfReportDateLT)
+	assert.Nil(t, params.PeriodOfReportDateLTE)
+	assert.Nil(t, params.PeriodOfReportDateGT)
+	assert.NotNil(t, params.PeriodOfReportDateGTE)
+	assert.NotNil(t, params.Timeframe)
+	assert.NotNil(t, params.IncludeSources)
+	assert.NotNil(t, params.Order)
+	assert.NotNil(t, params.Limit)
+	assert.NotNil(t, params.Sort)
+
+	assert.Equal(t, ticker, *params.Ticker)
+	assert.Equal(t, cik, *params.CIK)
+	assert.Equal(t, companyName, *params.CompanyNameFull)
+	assert.Equal(t, sic, *params.SIC)
+	assert.Equal(t, date, *params.FilingDateEQ)
+	assert.Equal(t, date, *params.PeriodOfReportDateGTE)
+	assert.Equal(t, timeframe, *params.Timeframe)
+	assert.Equal(t, includeSources, *params.IncludeSources)
+	assert.Equal(t, order, *params.Order)
+	assert.Equal(t, limit, *params.Limit)
+	assert.Equal(t, sort, *params.Sort)
+}

--- a/rest/models/indicators_test.go
+++ b/rest/models/indicators_test.go
@@ -13,11 +13,17 @@ func TestGetSMAParams(t *testing.T) {
 	order := models.Asc
 	expandUnderlying := true
 	ts := models.Millis(time.Now())
+	window := 4
+	seriesType := models.High
+	timespan := models.Minute
 	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
 
 	sma = *sma.WithAdjusted(adjusted)
 	sma = *sma.WithOrder(order)
 	sma = *sma.WithExpandUnderlying(expandUnderlying)
+	sma = *sma.WithTimespan(timespan)
+	sma = *sma.WithSeriesType(seriesType)
+	sma = *sma.WithWindow(window)
 
 	if *sma.Adjusted != adjusted {
 		t.Errorf("Adjusted not set correctly, got: %v, want: %v", *sma.Adjusted, adjusted)
@@ -29,6 +35,18 @@ func TestGetSMAParams(t *testing.T) {
 
 	if *sma.ExpandUnderlying != expandUnderlying {
 		t.Errorf("ExpandUnderlying not set correctly, got: %v, want: %v", *sma.ExpandUnderlying, expandUnderlying)
+	}
+
+	if *sma.Timespan != timespan {
+		t.Errorf("Timespan not set correctly, got: %v, want: %v", *sma.Timespan, timespan)
+	}
+
+	if *sma.SeriesType != seriesType {
+		t.Errorf("SeriesType not set correctly, got: %v, want: %v", *sma.SeriesType, seriesType)
+	}
+
+	if *sma.Window != window {
+		t.Errorf("Window not set correctly, got: %v, want: %v", *sma.Window, window)
 	}
 
 	for _, c := range allComparators {
@@ -64,11 +82,17 @@ func TestGetEMAParams(t *testing.T) {
 	order := models.Asc
 	expandUnderlying := true
 	ts := models.Millis(time.Now())
+	window := 4
+	seriesType := models.High
+	timespan := models.Minute
 	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
 
 	ema = *ema.WithAdjusted(adjusted)
 	ema = *ema.WithOrder(order)
 	ema = *ema.WithExpandUnderlying(expandUnderlying)
+	ema = *ema.WithTimespan(timespan)
+	ema = *ema.WithSeriesType(seriesType)
+	ema = *ema.WithWindow(window)
 
 	if *ema.Adjusted != adjusted {
 		t.Errorf("Adjusted not set correctly, got: %v, want: %v", *ema.Adjusted, adjusted)
@@ -80,6 +104,18 @@ func TestGetEMAParams(t *testing.T) {
 
 	if *ema.ExpandUnderlying != expandUnderlying {
 		t.Errorf("ExpandUnderlying not set correctly, got: %v, want: %v", *ema.ExpandUnderlying, expandUnderlying)
+	}
+
+	if *ema.Timespan != timespan {
+		t.Errorf("Timespan not set correctly, got: %v, want: %v", *ema.Timespan, timespan)
+	}
+
+	if *ema.SeriesType != seriesType {
+		t.Errorf("SeriesType not set correctly, got: %v, want: %v", *ema.SeriesType, seriesType)
+	}
+
+	if *ema.Window != window {
+		t.Errorf("Window not set correctly, got: %v, want: %v", *ema.Window, window)
 	}
 
 	for _, c := range allComparators {
@@ -115,11 +151,17 @@ func TestGetRSIParams(t *testing.T) {
 	order := models.Asc
 	expandUnderlying := true
 	ts := models.Millis(time.Now())
+	window := 4
+	seriesType := models.High
+	timespan := models.Minute
 	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
 
 	rsi = *rsi.WithAdjusted(adjusted)
 	rsi = *rsi.WithOrder(order)
 	rsi = *rsi.WithExpandUnderlying(expandUnderlying)
+	rsi = *rsi.WithTimespan(timespan)
+	rsi = *rsi.WithSeriesType(seriesType)
+	rsi = *rsi.WithWindow(window)
 
 	if *rsi.Adjusted != adjusted {
 		t.Errorf("Adjusted not set correctly, got: %v, want: %v", *rsi.Adjusted, adjusted)
@@ -131,6 +173,18 @@ func TestGetRSIParams(t *testing.T) {
 
 	if *rsi.ExpandUnderlying != expandUnderlying {
 		t.Errorf("ExpandUnderlying not set correctly, got: %v, want: %v", *rsi.ExpandUnderlying, expandUnderlying)
+	}
+
+	if *rsi.Timespan != timespan {
+		t.Errorf("Timespan not set correctly, got: %v, want: %v", *rsi.Timespan, timespan)
+	}
+
+	if *rsi.SeriesType != seriesType {
+		t.Errorf("SeriesType not set correctly, got: %v, want: %v", *rsi.SeriesType, seriesType)
+	}
+
+	if *rsi.Window != window {
+		t.Errorf("Window not set correctly, got: %v, want: %v", *rsi.Window, window)
 	}
 
 	for _, c := range allComparators {
@@ -166,11 +220,18 @@ func TestGetMACDParams(t *testing.T) {
 	order := models.Asc
 	expandUnderlying := true
 	ts := models.Millis(time.Now())
+	seriesType := models.High
+	timespan := models.Minute
 	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
 
 	macd = *macd.WithAdjusted(adjusted)
 	macd = *macd.WithOrder(order)
 	macd = *macd.WithExpandUnderlying(expandUnderlying)
+	macd = *macd.WithTimespan(timespan)
+	macd = *macd.WithSeriesType(seriesType)
+	macd = *macd.WithShortWindow(1)
+	macd = *macd.WithLongWindow(2)
+	macd = *macd.WithSignalWindow(3)
 
 	if *macd.Adjusted != adjusted {
 		t.Errorf("Adjusted not set correctly, got: %v, want: %v", *macd.Adjusted, adjusted)
@@ -182,6 +243,26 @@ func TestGetMACDParams(t *testing.T) {
 
 	if *macd.ExpandUnderlying != expandUnderlying {
 		t.Errorf("ExpandUnderlying not set correctly, got: %v, want: %v", *macd.ExpandUnderlying, expandUnderlying)
+	}
+
+	if *macd.Timespan != timespan {
+		t.Errorf("Timespan not set correctly, got: %v, want: %v", *macd.Timespan, timespan)
+	}
+
+	if *macd.SeriesType != seriesType {
+		t.Errorf("SeriesType not set correctly, got: %v, want: %v", *macd.SeriesType, seriesType)
+	}
+
+	if *macd.ShortWindow != 1 {
+		t.Errorf("ShortWindow not set correctly, got: %v, want: %v", *macd.ShortWindow, 1)
+	}
+
+	if *macd.LongWindow != 2 {
+		t.Errorf("LongWindow not set correctly, got: %v, want: %v", *macd.LongWindow, 2)
+	}
+
+	if *macd.SignalWindow != 3 {
+		t.Errorf("SignalWindow not set correctly, got: %v, want: %v", *macd.SignalWindow, 3)
 	}
 
 	for _, c := range allComparators {

--- a/rest/models/indicators_test.go
+++ b/rest/models/indicators_test.go
@@ -1,0 +1,212 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestGetSMAParams(t *testing.T) {
+	sma := models.GetSMAParams{}
+	adjusted := true
+	order := models.Asc
+	expandUnderlying := true
+	ts := models.Millis(time.Now())
+	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
+
+	sma = *sma.WithAdjusted(adjusted)
+	sma = *sma.WithOrder(order)
+	sma = *sma.WithExpandUnderlying(expandUnderlying)
+
+	if *sma.Adjusted != adjusted {
+		t.Errorf("Adjusted not set correctly, got: %v, want: %v", *sma.Adjusted, adjusted)
+	}
+
+	if *sma.Order != order {
+		t.Errorf("Order not set correctly, got: %v, want: %v", *sma.Order, order)
+	}
+
+	if *sma.ExpandUnderlying != expandUnderlying {
+		t.Errorf("ExpandUnderlying not set correctly, got: %v, want: %v", *sma.ExpandUnderlying, expandUnderlying)
+	}
+
+	for _, c := range allComparators {
+		sma = *sma.WithTimestamp(c, ts)
+		switch c {
+		case models.EQ:
+			if *sma.TimestampEQ != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *sma.TimestampEQ, ts)
+			}
+		case models.LT:
+			if *sma.TimestampLT != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *sma.TimestampLT, ts)
+			}
+		case models.LTE:
+			if *sma.TimestampLTE != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *sma.TimestampLTE, ts)
+			}
+		case models.GT:
+			if *sma.TimestampGT != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *sma.TimestampGT, ts)
+			}
+		case models.GTE:
+			if *sma.TimestampGTE != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *sma.TimestampGTE, ts)
+			}
+		}
+	}
+}
+
+func TestGetEMAParams(t *testing.T) {
+	ema := models.GetEMAParams{}
+	adjusted := true
+	order := models.Asc
+	expandUnderlying := true
+	ts := models.Millis(time.Now())
+	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
+
+	ema = *ema.WithAdjusted(adjusted)
+	ema = *ema.WithOrder(order)
+	ema = *ema.WithExpandUnderlying(expandUnderlying)
+
+	if *ema.Adjusted != adjusted {
+		t.Errorf("Adjusted not set correctly, got: %v, want: %v", *ema.Adjusted, adjusted)
+	}
+
+	if *ema.Order != order {
+		t.Errorf("Order not set correctly, got: %v, want: %v", *ema.Order, order)
+	}
+
+	if *ema.ExpandUnderlying != expandUnderlying {
+		t.Errorf("ExpandUnderlying not set correctly, got: %v, want: %v", *ema.ExpandUnderlying, expandUnderlying)
+	}
+
+	for _, c := range allComparators {
+		ema = *ema.WithTimestamp(c, ts)
+		switch c {
+		case models.EQ:
+			if *ema.TimestampEQ != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *ema.TimestampEQ, ts)
+			}
+		case models.LT:
+			if *ema.TimestampLT != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *ema.TimestampLT, ts)
+			}
+		case models.LTE:
+			if *ema.TimestampLTE != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *ema.TimestampLTE, ts)
+			}
+		case models.GT:
+			if *ema.TimestampGT != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *ema.TimestampGT, ts)
+			}
+		case models.GTE:
+			if *ema.TimestampGTE != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *ema.TimestampGTE, ts)
+			}
+		}
+	}
+}
+
+func TestGetRSIParams(t *testing.T) {
+	rsi := models.GetRSIParams{}
+	adjusted := true
+	order := models.Asc
+	expandUnderlying := true
+	ts := models.Millis(time.Now())
+	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
+
+	rsi = *rsi.WithAdjusted(adjusted)
+	rsi = *rsi.WithOrder(order)
+	rsi = *rsi.WithExpandUnderlying(expandUnderlying)
+
+	if *rsi.Adjusted != adjusted {
+		t.Errorf("Adjusted not set correctly, got: %v, want: %v", *rsi.Adjusted, adjusted)
+	}
+
+	if *rsi.Order != order {
+		t.Errorf("Order not set correctly, got: %v, want: %v", *rsi.Order, order)
+	}
+
+	if *rsi.ExpandUnderlying != expandUnderlying {
+		t.Errorf("ExpandUnderlying not set correctly, got: %v, want: %v", *rsi.ExpandUnderlying, expandUnderlying)
+	}
+
+	for _, c := range allComparators {
+		rsi = *rsi.WithTimestamp(c, ts)
+		switch c {
+		case models.EQ:
+			if *rsi.TimestampEQ != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *rsi.TimestampEQ, ts)
+			}
+		case models.LT:
+			if *rsi.TimestampLT != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *rsi.TimestampLT, ts)
+			}
+		case models.LTE:
+			if *rsi.TimestampLTE != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *rsi.TimestampLTE, ts)
+			}
+		case models.GT:
+			if *rsi.TimestampGT != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *rsi.TimestampGT, ts)
+			}
+		case models.GTE:
+			if *rsi.TimestampGTE != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *rsi.TimestampGTE, ts)
+			}
+		}
+	}
+}
+
+func TestGetMACDParams(t *testing.T) {
+	macd := models.GetMACDParams{}
+	adjusted := true
+	order := models.Asc
+	expandUnderlying := true
+	ts := models.Millis(time.Now())
+	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
+
+	macd = *macd.WithAdjusted(adjusted)
+	macd = *macd.WithOrder(order)
+	macd = *macd.WithExpandUnderlying(expandUnderlying)
+
+	if *macd.Adjusted != adjusted {
+		t.Errorf("Adjusted not set correctly, got: %v, want: %v", *macd.Adjusted, adjusted)
+	}
+
+	if *macd.Order != order {
+		t.Errorf("Order not set correctly, got: %v, want: %v", *macd.Order, order)
+	}
+
+	if *macd.ExpandUnderlying != expandUnderlying {
+		t.Errorf("ExpandUnderlying not set correctly, got: %v, want: %v", *macd.ExpandUnderlying, expandUnderlying)
+	}
+
+	for _, c := range allComparators {
+		macd = *macd.WithTimestamp(c, ts)
+		switch c {
+		case models.EQ:
+			if *macd.TimestampEQ != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *macd.TimestampEQ, ts)
+			}
+		case models.LT:
+			if *macd.TimestampLT != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *macd.TimestampLT, ts)
+			}
+		case models.LTE:
+			if *macd.TimestampLTE != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *macd.TimestampLTE, ts)
+			}
+		case models.GT:
+			if *macd.TimestampGT != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *macd.TimestampGT, ts)
+			}
+		case models.GTE:
+			if *macd.TimestampGTE != ts {
+				t.Errorf("Timestamp not set correctly, got: %v, want: %v", *macd.TimestampGTE, ts)
+			}
+		}
+	}
+}

--- a/rest/models/markets_test.go
+++ b/rest/models/markets_test.go
@@ -1,0 +1,51 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMarketHolidaysResponse(t *testing.T) {
+	holidays := models.GetMarketHolidaysResponse{
+		{
+			Exchange: "NYSE",
+			Name:     "New Year's Day",
+			Date:     models.Date(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+			Status:   "Closed",
+			Open:     models.Time{},
+			Close:    models.Time{},
+		},
+	}
+
+	assert.Equal(t, "NYSE", holidays[0].Exchange)
+	assert.Equal(t, "New Year's Day", holidays[0].Name)
+	assert.Equal(t, models.Date(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)), holidays[0].Date)
+	assert.Equal(t, "Closed", holidays[0].Status)
+	assert.Equal(t, models.Time{}, holidays[0].Open)
+	assert.Equal(t, models.Time{}, holidays[0].Close)
+}
+
+func TestGetMarketStatusResponse(t *testing.T) {
+	status := models.GetMarketStatusResponse{
+		AfterHours: true,
+		Currencies: map[string]string{
+			"USD": "US Dollar",
+		},
+		EarlyHours:    false,
+		Exchanges:     map[string]string{"NYSE": "New York Stock Exchange"},
+		IndicesGroups: map[string]string{"SPX": "S&P 500"},
+		Market:        "US",
+		ServerTime:    models.Time(time.Now()),
+	}
+
+	assert.True(t, status.AfterHours)
+	assert.Equal(t, "US Dollar", status.Currencies["USD"])
+	assert.False(t, status.EarlyHours)
+	assert.Equal(t, "New York Stock Exchange", status.Exchanges["NYSE"])
+	assert.Equal(t, "S&P 500", status.IndicesGroups["SPX"])
+	assert.Equal(t, "US", status.Market)
+	assert.NotNil(t, status.ServerTime)
+}

--- a/rest/models/quotes_test.go
+++ b/rest/models/quotes_test.go
@@ -1,0 +1,89 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListQuotesParams(t *testing.T) {
+	ticker := "AAPL"
+	limit := 100
+	order := models.Asc
+	sort := models.Timestamp
+
+	params := models.ListQuotesParams{
+		Ticker: ticker,
+	}
+
+	// Test WithTimestamp
+	params = *params.WithTimestamp(models.EQ, models.Nanos(time.Now()))
+	assert.NotNil(t, params.TimestampEQ)
+
+	// Test WithDay
+	params = *params.WithDay(2022, 2, 2)
+	assert.NotNil(t, params.TimestampEQ)
+
+	// Test WithOrder
+	params = *params.WithOrder(order)
+	assert.NotNil(t, params.Order)
+
+	// Test WithLimit
+	params = *params.WithLimit(limit)
+	assert.NotNil(t, params.Limit)
+
+	// Test WithSort
+	params = *params.WithSort(sort)
+	assert.NotNil(t, params.Sort)
+}
+
+func TestGetLastQuoteParams(t *testing.T) {
+	ticker := "AAPL"
+	params := models.GetLastQuoteParams{
+		Ticker: ticker,
+	}
+	assert.Equal(t, params.Ticker, ticker)
+}
+
+func TestGetLastForexQuoteParams(t *testing.T) {
+	from := "USD"
+	to := "EUR"
+
+	params := models.GetLastForexQuoteParams{
+		From: from,
+		To:   to,
+	}
+
+	assert.Equal(t, params.From, from)
+	assert.Equal(t, params.To, to)
+}
+
+func TestGetRealTimeCurrencyConversionParams(t *testing.T) {
+	from := "USD"
+	to := "EUR"
+
+	params := models.GetRealTimeCurrencyConversionParams{
+		From: from,
+		To:   to,
+	}
+
+	assert.Equal(t, params.From, from)
+	assert.Equal(t, params.To, to)
+}
+
+func TestQuote(t *testing.T) {
+	quote := models.Quote{}
+	assert.NotNil(t, quote)
+}
+
+func TestLastQuote(t *testing.T) {
+	lastQuote := models.LastQuote{}
+	assert.NotNil(t, lastQuote)
+}
+
+func TestForexQuote(t *testing.T) {
+	forexQuote := models.ForexQuote{}
+	assert.NotNil(t, forexQuote)
+}

--- a/rest/models/request_test.go
+++ b/rest/models/request_test.go
@@ -1,0 +1,50 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestOptions(t *testing.T) {
+	apiKey := "test_api_key"
+	headerKey := "Test-Header"
+	headerValue := "Test-Value"
+	queryKey := "test_query_key"
+	queryValue := "test_query_value"
+
+	opts := &models.RequestOptions{}
+	models.APIKey(apiKey)(opts)
+	models.Header(headerKey, headerValue)(opts)
+	models.QueryParam(queryKey, queryValue)(opts)
+
+	assert.NotNil(t, opts.APIKey)
+	assert.Equal(t, apiKey, *opts.APIKey)
+	assert.NotNil(t, opts.Headers)
+	assert.Equal(t, headerValue, opts.Headers.Get(headerKey))
+	assert.NotNil(t, opts.QueryParams)
+	assert.Equal(t, queryValue, opts.QueryParams.Get(queryKey))
+}
+
+func TestRequiredEdgeHeaders(t *testing.T) {
+	edgeID := "test_edge_id"
+	edgeIPAddress := "127.0.0.1"
+
+	opts := &models.RequestOptions{}
+	models.RequiredEdgeHeaders(edgeID, edgeIPAddress)(opts)
+
+	assert.NotNil(t, opts.Headers)
+	assert.Equal(t, edgeID, opts.Headers.Get(models.HeaderEdgeID))
+	assert.Equal(t, edgeIPAddress, opts.Headers.Get(models.HeaderEdgeIPAddress))
+}
+
+func TestEdgeUserAgent(t *testing.T) {
+	userAgent := "test_user_agent"
+
+	opts := &models.RequestOptions{}
+	models.EdgeUserAgent(userAgent)(opts)
+
+	assert.NotNil(t, opts.Headers)
+	assert.Equal(t, userAgent, opts.Headers.Get(models.HeaderEdgeUserAgent))
+}

--- a/rest/models/response_test.go
+++ b/rest/models/response_test.go
@@ -1,0 +1,37 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPaginationHooks_NextPage(t *testing.T) {
+	nextURL := "https://example.com/api/next?page=2"
+
+	hooks := models.PaginationHooks{
+		NextURL: nextURL,
+	}
+
+	assert.Equal(t, nextURL, hooks.NextPage())
+}
+
+func TestErrorResponse_Error(t *testing.T) {
+	statusCode := 400
+	status := "ERROR"
+	requestID := "test_request_id"
+	errorMessage := "An error occurred"
+
+	errorResp := &models.ErrorResponse{
+		BaseResponse: models.BaseResponse{
+			Status:       status,
+			RequestID:    requestID,
+			ErrorMessage: errorMessage,
+		},
+		StatusCode: statusCode,
+	}
+
+	expectedError := "bad status with code '400': message 'An error occurred': request ID 'test_request_id': internal status: 'ERROR'"
+	assert.Equal(t, expectedError, errorResp.Error())
+}

--- a/rest/models/snapshot_test.go
+++ b/rest/models/snapshot_test.go
@@ -1,0 +1,79 @@
+package models
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetAllTickersSnapshotParams_WithTickers(t *testing.T) {
+	params := GetAllTickersSnapshotParams{}
+	tickers := "AAPL,GOOG,AMZN"
+	params = *params.WithTickers(tickers)
+	assert.Equal(t, tickers, *params.Tickers)
+}
+
+func TestGetAllTickersSnapshotParams_WithIncludeOTC(t *testing.T) {
+	params := GetAllTickersSnapshotParams{}
+	otc := true
+	params = *params.WithIncludeOTC(otc)
+	assert.Equal(t, otc, *params.IncludeOTC)
+}
+
+func TestGetGainersLosersSnapshotParams_WithIncludeOTC(t *testing.T) {
+	params := GetGainersLosersSnapshotParams{}
+	otc := true
+	params = *params.WithIncludeOTC(otc)
+	assert.Equal(t, otc, *params.IncludeOTC)
+}
+
+func TestListOptionsChainParams_WithStrikePrice(t *testing.T) {
+	params := ListOptionsChainParams{}
+	strikePrice := 100.0
+	params = *params.WithStrikePrice(strikePrice)
+	assert.Equal(t, strikePrice, *params.StrikePrice)
+}
+
+func TestListOptionsChainParams_WithContractType(t *testing.T) {
+	params := ListOptionsChainParams{}
+	contractType := ContractCall
+	params = *params.WithContractType(contractType)
+	assert.Equal(t, contractType, *params.ContractType)
+}
+
+func TestListOptionsChainParams_WithLimit(t *testing.T) {
+	params := ListOptionsChainParams{}
+	limit := 50
+	params = *params.WithLimit(limit)
+	assert.Equal(t, limit, *params.Limit)
+}
+
+func TestListOptionsChainParams_WithExpirationDate(t *testing.T) {
+	params := ListOptionsChainParams{}
+	expirationDate := Date(time.Date(2022, 2, 2, 0, 0, 0, 0, time.Local))
+	comparator := EQ
+	params = *params.WithExpirationDate(comparator, expirationDate)
+	assert.Equal(t, expirationDate, *params.ExpirationDateEQ)
+}
+
+func TestListOptionsChainParams_WithOrder(t *testing.T) {
+	params := ListOptionsChainParams{}
+	order := Asc
+	params = *params.WithOrder(order)
+	assert.Equal(t, order, *params.Order)
+}
+
+func TestListOptionsChainParams_WithSort(t *testing.T) {
+	params := ListOptionsChainParams{}
+	sort := TickerSymbol
+	params = *params.WithSort(sort)
+	assert.Equal(t, sort, *params.Sort)
+}
+
+func TestGetIndicesSnapshotParams_WithTickerAnyOf(t *testing.T) {
+	params := GetIndicesSnapshotParams{}
+	tickers := []string{"AAPL", "GOOG", "AMZN"}
+	params = *params.WithTickerAnyOf(tickers...)
+	assert.Equal(t, strings.Join(tickers, ","), *params.TickerAnyOf)
+}

--- a/rest/models/splits_test.go
+++ b/rest/models/splits_test.go
@@ -1,0 +1,75 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListSplitsParams(t *testing.T) {
+	ticker := "AAPL"
+	date := models.Date(time.Date(2022, 2, 2, 0, 0, 0, 0, time.Local))
+	reverseSplit := true
+	order := models.Asc
+	limit := 20
+	sort := models.TickerSymbol
+	allComparators := [5]models.Comparator{models.EQ, models.LT, models.LTE, models.GT, models.GTE}
+
+	t.Run("Test WithTicker", func(t *testing.T) {
+		for _, c := range allComparators {
+			params := models.ListSplitsParams{}.WithTicker(c, ticker)
+			switch c {
+			case models.EQ:
+				assert.Equal(t, &ticker, params.TickerEQ)
+			case models.LT:
+				assert.Equal(t, &ticker, params.TickerLT)
+			case models.LTE:
+				assert.Equal(t, &ticker, params.TickerLTE)
+			case models.GT:
+				assert.Equal(t, &ticker, params.TickerGT)
+			case models.GTE:
+				assert.Equal(t, &ticker, params.TickerGTE)
+			}
+		}
+	})
+
+	t.Run("Test WithExecutionDate", func(t *testing.T) {
+		for _, c := range allComparators {
+			params := models.ListSplitsParams{}.WithExecutionDate(c, date)
+			switch c {
+			case models.EQ:
+				assert.Equal(t, &date, params.ExecutionDateEQ)
+			case models.LT:
+				assert.Equal(t, &date, params.ExecutionDateLT)
+			case models.LTE:
+				assert.Equal(t, &date, params.ExecutionDateLTE)
+			case models.GT:
+				assert.Equal(t, &date, params.ExecutionDateGT)
+			case models.GTE:
+				assert.Equal(t, &date, params.ExecutionDateGTE)
+			}
+		}
+	})
+
+	t.Run("Test WithReverseSplit", func(t *testing.T) {
+		params := models.ListSplitsParams{}.WithReverseSplit(reverseSplit)
+		assert.Equal(t, &reverseSplit, params.ReverseSplit)
+	})
+
+	t.Run("Test WithOrder", func(t *testing.T) {
+		params := models.ListSplitsParams{}.WithOrder(order)
+		assert.Equal(t, &order, params.Order)
+	})
+
+	t.Run("Test WithLimit", func(t *testing.T) {
+		params := models.ListSplitsParams{}.WithLimit(limit)
+		assert.Equal(t, &limit, params.Limit)
+	})
+
+	t.Run("Test WithSort", func(t *testing.T) {
+		params := models.ListSplitsParams{}.WithSort(sort)
+		assert.Equal(t, &sort, params.Sort)
+	})
+}

--- a/rest/models/summaries_test.go
+++ b/rest/models/summaries_test.go
@@ -1,0 +1,18 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSummaryParams(t *testing.T) {
+	tickers := []string{"AAPL", "GOOG", "MSFT"}
+
+	t.Run("Test WithTickerAnyOf", func(t *testing.T) {
+		params := models.GetSummaryParams{}.WithTickerAnyOf(tickers...)
+		assert.NotNil(t, params.TickerAnyOf)
+		assert.Equal(t, "AAPL,GOOG,MSFT", *params.TickerAnyOf)
+	})
+}

--- a/rest/models/tickers_test.go
+++ b/rest/models/tickers_test.go
@@ -1,0 +1,78 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListTickersParams(t *testing.T) {
+	params := models.ListTickersParams{}
+	params = *params.WithTicker(models.EQ, "AAPL").
+		WithType("Stock").
+		WithMarket(models.AssetStocks).
+		WithExchange("NASDAQ").
+		WithCUSIP(12345).
+		WithCIK(67890).
+		WithDate(models.Date(time.Date(2022, 2, 2, 0, 0, 0, 0, time.Local))).
+		WithActive(true).
+		WithSearch("Apple").
+		WithSort(models.TickerSymbol).
+		WithOrder(models.Asc).
+		WithLimit(100)
+
+	assert.Equal(t, "AAPL", *params.TickerEQ)
+	assert.Equal(t, "Stock", *params.Type)
+	assert.Equal(t, models.AssetStocks, *params.Market)
+	assert.Equal(t, "NASDAQ", *params.Exchange)
+	assert.Equal(t, 12345, *params.CUSIP)
+	assert.Equal(t, 67890, *params.CIK)
+	assert.Equal(t, models.Date(time.Date(2022, 2, 2, 0, 0, 0, 0, time.Local)), *params.Date)
+	assert.Equal(t, true, *params.Active)
+	assert.Equal(t, "Apple", *params.Search)
+	assert.Equal(t, models.TickerSymbol, *params.Sort)
+	assert.Equal(t, models.Asc, *params.Order)
+	assert.Equal(t, 100, *params.Limit)
+}
+
+func TestGetTickerDetailsParams(t *testing.T) {
+	params := models.GetTickerDetailsParams{Ticker: "AAPL"}
+	params = *params.WithDate(models.Date(time.Date(2022, 2, 2, 0, 0, 0, 0, time.Local)))
+
+	assert.Equal(t, "AAPL", params.Ticker)
+	assert.Equal(t, models.Date(time.Date(2022, 2, 2, 0, 0, 0, 0, time.Local)), *params.Date)
+}
+
+func TestListTickerNewsParams(t *testing.T) {
+	millis := models.Millis(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))
+	params := models.ListTickerNewsParams{}
+	params = *params.WithTicker(models.EQ, "AAPL").
+		WithPublishedUTC(models.GT, millis).
+		WithSort(models.TickerSymbol).
+		WithOrder(models.Asc).
+		WithLimit(100)
+
+	assert.Equal(t, "AAPL", *params.TickerEQ)
+	assert.Equal(t, millis, *params.PublishedUtcGT)
+	assert.Equal(t, models.TickerSymbol, *params.Sort)
+	assert.Equal(t, models.Asc, *params.Order)
+	assert.Equal(t, 100, *params.Limit)
+}
+
+func TestGetTickerTypesParams(t *testing.T) {
+	params := models.GetTickerTypesParams{}
+	params = *params.WithAssetClass(models.AssetStocks).WithLocale(models.US)
+
+	assert.Equal(t, models.AssetStocks, *params.AssetClass)
+	assert.Equal(t, models.US, *params.Locale)
+}
+
+func TestGetTickerEventsParams(t *testing.T) {
+	params := models.GetTickerEventsParams{ID: "AAPL"}
+	params = *params.WithTypes("ticker_change")
+
+	assert.Equal(t, "AAPL", params.ID)
+	assert.Equal(t, "ticker_change", *params.Types)
+}

--- a/rest/models/trades_test.go
+++ b/rest/models/trades_test.go
@@ -1,0 +1,47 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListTradesParams(t *testing.T) {
+	params := models.ListTradesParams{Ticker: "AAPL"}
+
+	// Test WithTimestamp
+	paramsWithTimestamp := params.WithTimestamp(models.EQ, models.Nanos(time.Date(2022, 2, 2, 0, 0, 0, 0, time.UTC)))
+	assert.Equal(t,models.Nanos(time.Date(2022, 2, 2, 0, 0, 0, 0, time.UTC)), *paramsWithTimestamp.TimestampEQ)
+
+	// Test WithDay
+	paramsWithDay := params.WithDay(2022, 2, 2)
+	assert.Equal(t, models.Nanos(time.Date(2022, 2, 2, 0, 0, 0, 0, time.UTC)), *paramsWithDay.TimestampEQ)
+
+	// Test WithOrder
+	order := models.Asc
+	paramsWithOrder := params.WithOrder(order)
+	assert.Equal(t, &order, paramsWithOrder.Order)
+
+	// Test WithLimit
+	limit := 100
+	paramsWithLimit := params.WithLimit(limit)
+	assert.Equal(t, &limit, paramsWithLimit.Limit)
+
+	// Test WithSort
+	sort := models.Timestamp
+	paramsWithSort := params.WithSort(sort)
+	assert.Equal(t, &sort, paramsWithSort.Sort)
+}
+
+func TestGetLastTradeParams(t *testing.T) {
+	params := models.GetLastTradeParams{Ticker: "AAPL"}
+	assert.Equal(t, "AAPL", params.Ticker)
+}
+
+func TestGetLastCryptoTradeParams(t *testing.T) {
+	params := models.GetLastCryptoTradeParams{From: "BTC", To: "USD"}
+	assert.Equal(t, "BTC", params.From)
+	assert.Equal(t, "USD", params.To)
+}

--- a/rest/models/types_test.go
+++ b/rest/models/types_test.go
@@ -78,3 +78,49 @@ func TestUnmarshalTime(t *testing.T) {
 		})
 	}
 }
+
+func TestTime_MarshalUnmarshal(t *testing.T) {
+	ti := models.Time(time.Date(2022, 2, 2, 0, 0, 0, 0, time.UTC))
+	data, err := json.Marshal(&ti)
+	assert.NoError(t, err)
+	assert.Equal(t, "\"2022-02-02T00:00:00.000Z\"", string(data))
+
+	var unmarshaled models.Time
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, ti, unmarshaled)
+}
+
+func TestDate_MarshalUnmarshal(t *testing.T) {
+	date := models.Date(time.Date(2022, 2, 2, 0, 0, 0, 0, time.UTC))
+	data, err := json.Marshal(&date)
+	assert.NoError(t, err)
+	assert.Equal(t, "\"2022-02-02\"", string(data))
+
+	var unmarshaled models.Date
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, date, unmarshaled)
+}
+
+func TestMillis_MarshalUnmarshal(t *testing.T) {
+	millis := models.Millis(time.Date(2022, 2, 2, 0, 0, 0, 0, time.UTC))
+	data, err := json.Marshal(&millis)
+	assert.NoError(t, err)
+
+	var unmarshaled models.Millis
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Time(millis).UnixMilli(), time.Time(unmarshaled).UnixMilli())
+}
+
+func TestNanos_MarshalUnmarshal(t *testing.T) {
+	nanos := models.Nanos(time.Now())
+	data, err := json.Marshal(&nanos)
+	assert.NoError(t, err)
+
+	var unmarshaled models.Nanos
+	err = json.Unmarshal(data, &unmarshaled)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Time(nanos).UnixNano(), time.Time(unmarshaled).UnixNano())
+}

--- a/websocket/config_test.go
+++ b/websocket/config_test.go
@@ -1,0 +1,76 @@
+package polygonws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testLogger struct{}
+
+func (l *testLogger) Debugf(template string, args ...interface{}) {}
+func (l *testLogger) Infof(template string, args ...interface{})  {}
+func (l *testLogger) Errorf(template string, args ...interface{}) {}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Run("InvalidConfig", func(t *testing.T) {
+		cfg := &Config{}
+		err := cfg.validate()
+		require.Error(t, err)
+		assert.Equal(t, "API key is required", err.Error())
+	})
+
+	t.Run("ValidConfig", func(t *testing.T) {
+		cfg := &Config{
+			APIKey: "test-api-key",
+		}
+		err := cfg.validate()
+		require.NoError(t, err)
+	})
+}
+
+func TestMarket_Supports(t *testing.T) {
+	t.Run("ValidSupport", func(t *testing.T) {
+		m := Stocks
+		topic := StocksTrades
+		assert.True(t, m.supports(topic))
+	})
+
+	t.Run("InvalidSupport", func(t *testing.T) {
+		m := Stocks
+		topic := OptionsTrades
+		assert.False(t, m.supports(topic))
+	})
+}
+
+func TestTopicPrefix(t *testing.T) {
+	testCases := []struct {
+			name   string
+			topic  Topic
+			prefix string
+	}{
+			{"StocksSecAggs", StocksSecAggs, "A"},
+			{"StocksMinAggs", StocksMinAggs, "AM"},
+			{"StocksTrades", StocksTrades, "T"},
+			{"StocksQuotes", StocksQuotes, "Q"},
+			{"StocksImbalances", StocksImbalances, "NOI"},
+			{"StocksLULD", StocksLULD, "LULD"},
+			{"OptionsSecAggs", OptionsSecAggs, "A"},
+			{"OptionsMinAggs", OptionsMinAggs, "AM"},
+			{"OptionsTrades", OptionsTrades, "T"},
+			{"OptionsQuotes", OptionsQuotes, "Q"},
+			{"ForexMinAggs", ForexMinAggs, "CA"},
+			{"ForexQuotes", ForexQuotes, "C"},
+			{"CryptoMinAggs", CryptoMinAggs, "XA"},
+			{"CryptoTrades", CryptoTrades, "XT"},
+			{"CryptoQuotes", CryptoQuotes, "XQ"},
+			{"CryptoL2Book", CryptoL2Book, "XL2"},
+	}
+
+	for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+					assert.Equal(t, tc.prefix, tc.topic.prefix())
+			})
+	}
+}


### PR DESCRIPTION
This will be paired with a change to the test-coverage file to exclude examples which will get our coverage over 80%, but I don't have permissions to change that file, so I've reverted just that portion. This test coverage is the last thing needed to submit to the Awesome Go Library.