### PR TITLE
Add error checking to spec downloader

### DIFF
--- a/.polygon/rest.go
+++ b/.polygon/rest.go
@@ -37,7 +37,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	os.WriteFile(".polygon/rest.json", out.Bytes(), 0644)
+	err = os.WriteFile(".polygon/rest.json", out.Bytes(), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func isURL(uri string) bool {


### PR DESCRIPTION
Added error checking to log if file cannot be created. I'm new to spec changes to attempted to download an update by running `rest.go` from the `.polygon` directory and it seemed to work but was failing silently. This check will be you the heads up by logging the error below:

```bash
$ go run rest.go https://api.polygon.io/openapi
2023/04/25 22:41:51 open .polygon/rest.json: no such file or directory
exit status 1
```

This likely is connected to automation and the expected execution is up a level via `go run .polygon/rest.go https://api.polygon.io/openapi` from the root of the client library.