### PR TITLE
move rawData output into processData()

### DIFF
--- a/websocket/polygon.go
+++ b/websocket/polygon.go
@@ -353,6 +353,11 @@ func (c *Client) process() (err error) {
 		case <-c.ptomb.Dying():
 			return nil
 		case data := <-c.rQueue:
+			if c.rawData {
+				c.output <- data
+				continue
+			}
+
 			var msgs []json.RawMessage
 			if err := json.Unmarshal(data, &msgs); err != nil {
 				c.log.Errorf("failed to process raw messages: %v", err)
@@ -414,11 +419,6 @@ func (c *Client) handleStatus(msg json.RawMessage) error {
 }
 
 func (c *Client) handleData(eventType string, msg json.RawMessage) {
-	if c.rawData {
-		c.output <- msg // push raw data to output channel
-		return
-	}
-
 	switch eventType {
 	case "A":
 		var out models.EquityAgg


### PR DESCRIPTION
The client does a bunch of processing prior to returning raw data which can impact performance.

In my case, I would like to:
- reduce number of json deserializations to 1 (currently, even if consuming raw data, one must do 3 since 2 calls to json.Unmarshall() prior to pushing out the raw data)
- moving to a different more performant json deserialization package (many to choose from)