### PR TITLE
added client code and examples for new v3 snapshot endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-40.6%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-40.4%25-yellow)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -76,7 +76,6 @@ func (c *Client) CallURL(ctx context.Context, method, uri string, response any, 
 	req.SetHeaderMultiValues(options.Headers)
 	req.SetResult(response).SetError(&models.ErrorResponse{})
 
-	fmt.Println("uri", uri)
 	res, err := req.Execute(method, uri)
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -76,6 +76,7 @@ func (c *Client) CallURL(ctx context.Context, method, uri string, response any, 
 	req.SetHeaderMultiValues(options.Headers)
 	req.SetResult(response).SetError(&models.ErrorResponse{})
 
+	fmt.Println("uri", uri)
 	res, err := req.Execute(method, uri)
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)

--- a/rest/example/options/snapshots-assets/main.go
+++ b/rest/example/options/snapshots-assets/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+	// Init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// Set parameters
+	params := models.ListAssetSnapshotsParams{}.
+		WithTickerAnyOf("AAPL,META,F").
+		WithTimestamp(models.EQ, models.Nanos(time.Date(2023, 05, 8, 0, 0, 0, 0, time.UTC)))
+
+	// Make request
+	iter := c.ListAssetSnapshots(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Println(iter.Item())
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+}

--- a/rest/example/stocks/snapshots-assets/main.go
+++ b/rest/example/stocks/snapshots-assets/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	polygon "github.com/polygon-io/client-go/rest"
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func main() {
+	// Init client
+	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
+
+	// Set parameters
+	params := models.ListAssetSnapshotsParams{}.
+		WithTickerAnyOf("AAPL,META,F").
+		WithTimestamp(models.EQ, models.Nanos(time.Date(2023, 05, 8, 0, 0, 0, 0, time.UTC)))
+
+	// Make request
+	iter := c.ListAssetSnapshots(context.Background(), params)
+
+	// do something with the result
+	for iter.Next() {
+		log.Println(iter.Item())
+	}
+	if iter.Err() != nil {
+		log.Fatal(iter.Err())
+	}
+}

--- a/rest/models/snapshot.go
+++ b/rest/models/snapshot.go
@@ -1,6 +1,8 @@
 package models
 
-import "strings"
+import (
+	"strings"
+)
 
 // GetAllTickersSnapshotParams is the set of parameters for the GetAllTickersSnapshot method.
 type GetAllTickersSnapshotParams struct {
@@ -377,4 +379,63 @@ type FullBookSnapshot struct {
 type OrderBookQuote struct {
 	Price            float64            `json:"p,omitempty"`
 	ExchangeToShares map[string]float64 `json:"x,omitempty"`
+}
+
+type ListAssetSnapshotsParams struct {
+	TickerAnyOf  *string `query:"ticker.any_of"`
+	Ticker       *string `query:"ticker"`
+	Type         *string `query:"type"`
+	TimestampLT  *Nanos  `query:"timestamp.lt"`
+	TimestampLTE *Nanos  `query:"timestamp.lte"`
+	TimestampGT  *Nanos  `query:"timestamp.gt"`
+	TimestampGTE *Nanos  `query:"timestamp.gte"`
+}
+
+func (p ListAssetSnapshotsParams) WithTickerAnyOf(q string) *ListAssetSnapshotsParams {
+	p.TickerAnyOf = &q
+	return &p
+}
+
+func (p ListAssetSnapshotsParams) WithTicker(q string) *ListAssetSnapshotsParams {
+	p.Ticker = &q
+	return &p
+}
+
+func (p ListAssetSnapshotsParams) WithType(q string) *ListAssetSnapshotsParams {
+	p.Type = &q
+	return &p
+}
+
+func (p ListAssetSnapshotsParams) WithTimestamp(c Comparator, q Nanos) *ListAssetSnapshotsParams {
+	switch c {
+	case LT:
+		p.TimestampLT = &q
+	case LTE:
+		p.TimestampLTE = &q
+	case GT:
+		p.TimestampGT = &q
+	case GTE:
+		p.TimestampGTE = &q
+	}
+	return &p
+}
+
+type ListAssetSnapshotsResponse struct {
+	BaseResponse
+	Status    string          `json:"status"`
+	RequestID string          `json:"request_id"`
+	NextURL   string          `json:"next_url,omitempty"`
+	Results   []AssetSnapshot `json:"results,omitempty"`
+}
+
+type AssetSnapshot struct {
+	MarketStatus string                 `json:"market_status"`
+	Name         string                 `json:"name"`
+	Session      map[string]interface{} `json:"session"`
+	Details      map[string]interface{} `json:"details,omitempty"`
+	LastQuote    map[string]interface{} `json:"last_quote,omitempty"`
+	LastTrade    map[string]interface{} `json:"last_trade,omitempty"`
+	Greeks       map[string]interface{} `json:"greeks,omitempty"`
+	Ticker       string                 `json:"ticker"`
+	Type         string                 `json:"type"`
 }

--- a/rest/snapshot.go
+++ b/rest/snapshot.go
@@ -17,6 +17,7 @@ const (
 	ListOptionsChainSnapshotPath  = "/v3/snapshot/options/{underlyingAsset}"
 	GetCryptoFullBookSnapshotPath = "/v2/snapshot/locale/global/markets/crypto/tickers/{ticker}/book"
 	GetIndicesSnapshotPath        = "/v3/snapshot/indices"
+	ListAssetSnapshots            = "/v3/snapshot"
 )
 
 // SnapshotClient defines a REST client for the Polygon snapshot API.
@@ -109,4 +110,13 @@ func (ac *SnapshotClient) GetIndicesSnapshot(ctx context.Context, params *models
 	res := &models.GetIndicesSnapshotResponse{}
 	err := ac.Call(ctx, http.MethodGet, GetIndicesSnapshotPath, params, res, opts...)
 	return res, err
+}
+
+// TODO: Comment
+func (ac *SnapshotClient) ListAssetSnapshots(ctx context.Context, params *models.ListAssetSnapshotsParams, options ...models.RequestOption) *iter.Iter[models.AssetSnapshot] {
+	return iter.NewIter(ctx, ListAssetSnapshots, params, func(uri string) (iter.ListResponse, []models.AssetSnapshot, error) {
+		res := &models.ListAssetSnapshotsResponse{}
+		err := ac.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
 }

--- a/rest/snapshot.go
+++ b/rest/snapshot.go
@@ -112,7 +112,19 @@ func (ac *SnapshotClient) GetIndicesSnapshot(ctx context.Context, params *models
 	return res, err
 }
 
-// TODO: Comment
+// ListAssetSnapshots retrieves the snapshots for the specified tickers for the specified time. For more details see:
+// - https://staging.polygon.io/docs/stocks/get_v3_snapshot
+// - https://staging.polygon.io/docs/options/get_v3_snapshot
+//
+// This method returns an iterator that should be used to access the results via this pattern:
+//
+//	iter := c.ListAssetSnapshots(context, params, opts...)
+//	for iter.Next() {
+//		log.Print(iter.Item()) // do something with the current value
+//	}
+//	if iter.Err() != nil {
+//		return iter.Err()
+//	}
 func (ac *SnapshotClient) ListAssetSnapshots(ctx context.Context, params *models.ListAssetSnapshotsParams, options ...models.RequestOption) *iter.Iter[models.AssetSnapshot] {
 	return iter.NewIter(ctx, ListAssetSnapshots, params, func(uri string) (iter.ListResponse, []models.AssetSnapshot, error) {
 		res := &models.ListAssetSnapshotsResponse{}


### PR DESCRIPTION
- Added client code and tests for the new `v3/snapshot` endpoint.

Issue: https://app.zenhub.com/workspaces/backend-6042935fc77665000f50780e/issues/gh/polygon-io/backend/1036
Docs: https://staging.polygon.io/docs/stocks/get_v3_snapshot