### PR TITLE
Added request tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-39.3%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-39.2%25-yellow)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -88,6 +88,18 @@ func (c *Client) CallURL(ctx context.Context, method, uri string, response any, 
 		return errRes
 	}
 
+	if options.Trace {
+		fmt.Printf("Request URL: %s\n", uri)
+		sanitizedHeaders := req.Header
+		for k := range sanitizedHeaders {
+			if k == "Authorization" {
+				sanitizedHeaders[k] = []string{"REDACTED"}
+			}
+		}
+		fmt.Printf("Request Headers: %s\n", sanitizedHeaders)
+		fmt.Printf("Response Headers: %+v\n", res.Header())
+	}
+
 	return nil
 }
 

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -76,64 +76,7 @@ func (c *Client) CallURL(ctx context.Context, method, uri string, response any, 
 	req.SetHeaderMultiValues(options.Headers)
 	req.SetResult(response).SetError(&models.ErrorResponse{})
 
-	// Enable Rusty connection traceinfo (before request)
-	if options.Trace {
-		req.EnableTrace()
-	}
-
 	res, err := req.Execute(method, uri)
-
-	// Explore request and response trace info
-	if options.Trace {
-
-		// Explore trace info
-		fmt.Println("Request Info:")
-		ti := res.Request.TraceInfo()
-		fmt.Println("  DNSLookup     :", ti.DNSLookup)
-		fmt.Println("  ConnTime      :", ti.ConnTime)
-		fmt.Println("  TCPConnTime   :", ti.TCPConnTime)
-		fmt.Println("  TLSHandshake  :", ti.TLSHandshake)
-		fmt.Println("  ServerTime    :", ti.ServerTime)
-		fmt.Println("  ResponseTime  :", ti.ResponseTime)
-		fmt.Println("  TotalTime     :", ti.TotalTime)
-		fmt.Println("  IsConnReused  :", ti.IsConnReused)
-		fmt.Println("  IsConnWasIdle :", ti.IsConnWasIdle)
-		fmt.Println("  ConnIdleTime  :", ti.ConnIdleTime)
-		fmt.Println("  RequestAttempt:", ti.RequestAttempt)
-		fmt.Println("  RemoteAddr    :", ti.RemoteAddr.String())
-		fmt.Println("  Request URL   :", method, uri)
-		fmt.Println()
-
-		fmt.Println("Request Headers:")
-		sanitizedHeaders := req.Header
-		for k := range sanitizedHeaders {
-			if k == "Authorization" {
-				sanitizedHeaders[k] = []string{"REDACTED"}
-			}
-		}
-		for k, v := range sanitizedHeaders {
-			fmt.Printf("  %v: %v\n", k, v)
-		}
-		fmt.Println()
-
-		// Explore response object
-		fmt.Println("Response Info:")
-		fmt.Println("  Error      :", err)
-		fmt.Println("  Status Code:", res.StatusCode())
-		fmt.Println("  Status     :", res.Status())
-		fmt.Println("  Proto      :", res.Proto())
-		fmt.Println("  Time       :", res.Time())
-		fmt.Println("  Received At:", res.ReceivedAt())
-		fmt.Println()
-
-		fmt.Println("Response Headers:")
-		for k, v := range res.Header() {
-			fmt.Printf("  %v: %v\n", k, v)
-		}
-		fmt.Println()
-
-	}
-
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	} else if res.IsError() {
@@ -143,6 +86,18 @@ func (c *Client) CallURL(ctx context.Context, method, uri string, response any, 
 			errRes.RequestID = res.Header().Get("X-Request-ID")
 		}
 		return errRes
+	}
+
+	if options.Trace {
+		fmt.Printf("Request URL: %s\n", uri)
+		sanitizedHeaders := req.Header
+		for k := range sanitizedHeaders {
+			if k == "Authorization" {
+				sanitizedHeaders[k] = []string{"REDACTED"}
+			}
+		}
+		fmt.Printf("Request Headers: %s\n", sanitizedHeaders)
+		fmt.Printf("Response Headers: %+v\n", res.Header())
 	}
 
 	return nil

--- a/rest/models/request.go
+++ b/rest/models/request.go
@@ -15,6 +15,9 @@ type RequestOptions struct {
 
 	// Query params to apply to the request
 	QueryParams url.Values
+
+	// Trace enables request tracing
+	Trace bool
 }
 
 // RequestOption changes the configuration of RequestOptions.
@@ -74,4 +77,11 @@ func RequiredEdgeHeaders(edgeID, edgeIPAddress string) RequestOption {
 // EdgeUserAgent sets the Launchpad optional header denoting the Edge User's UserAgent.
 func EdgeUserAgent(userAgent string) RequestOption {
 	return Header(HeaderEdgeUserAgent, userAgent)
+}
+
+// WithTrace enables or disables request tracing.
+func WithTrace(trace bool) RequestOption {
+	return func(o *RequestOptions) {
+		o.Trace = trace
+	}
 }


### PR DESCRIPTION
A new optional trace parameter in RequestOption enables request and response logging for debugging. When activated via ` models.WithTrace(true)` on the request, the requested URL, sanitized request headers, and response headers are printed to the console.

Here's an example script:

```
package main

import (
	"context"
	"log"
	"os"
	"time"
	"fmt"

	polygon "github.com/polygon-io/client-go/rest"
	"github.com/polygon-io/client-go/rest/models"
)

func main() {

	// init client
	c := polygon.New(os.Getenv("POLYGON_API_KEY"))

	// set params
	params := models.ListAggsParams{
		Ticker:     "AAPL",
		Multiplier: 1,
		Timespan:   "minute",
		From:       models.Millis(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)),
		To:         models.Millis(time.Date(2023, 6, 14, 0, 0, 0, 0, time.UTC)),
	}.WithOrder(models.Desc).WithLimit(50000).WithAdjusted(true)

	var count int64

	// make request
	iter := c.ListAggs(context.Background(), params, models.WithTrace(true))

	// do something with the result
	for iter.Next() {
		//log.Print(iter.Item())
		count++
	}
	if iter.Err() != nil {
		log.Fatal(iter.Err())
	}

	fmt.Println(count)

}
```


The output looks like this:

```
go run main.go
Request URL: /v2/aggs/ticker/AAPL/range/1/minute/1640995200000/1686700800000?adjusted=true&limit=50000&sort=desc
Request Headers: map[Accept-Encoding:[gzip] Authorization:[REDACTED] User-Agent:[Polygon.io GoClient/v1.11.0]]
Response Headers: map[Content-Encoding:[gzip] Content-Type:[application/json] Date:[Fri, 16 Jun 2023 16:51:17 GMT] Server:[nginx/1.19.2] Strict-Transport-Security:[max-age=15724800; includeSubDomains] Vary:[Accept-Encoding] X-Request-Id:[415a486ea6db0dc513b8cd5410f50a13]]
Request URL: https://api.polygon.io/v2/aggs/ticker/AAPL/range/1/minute/1640995200000/1678393019999?cursor=bGltaXQ9NTAwMDAmc29ydD1kZXNj
Request Headers: map[Accept-Encoding:[gzip] Authorization:[REDACTED] User-Agent:[Polygon.io GoClient/v1.11.0]]
Response Headers: map[Content-Encoding:[gzip] Content-Type:[application/json] Date:[Fri, 16 Jun 2023 16:51:18 GMT] Server:[nginx/1.19.2] Strict-Transport-Security:[max-age=15724800; includeSubDomains] Vary:[Accept-Encoding] X-Request-Id:[f09d612c43f730c94bc9306a02a4f7aa]]
Request URL: https://api.polygon.io/v2/aggs/ticker/AAPL/range/1/minute/1640995200000/1670354219999?cursor=bGltaXQ9NTAwMDAmc29ydD1kZXNj
Request Headers: map[Accept-Encoding:[gzip] Authorization:[REDACTED] User-Agent:[Polygon.io GoClient/v1.11.0]]
Response Headers: map[Content-Encoding:[gzip] Content-Type:[application/json] Date:[Fri, 16 Jun 2023 16:51:19 GMT] Server:[nginx/1.19.2] Strict-Transport-Security:[max-age=15724800; includeSubDomains] Vary:[Accept-Encoding] X-Request-Id:[6fa0ec5a65368624cf7afb8df970fc2a]]
Request URL: https://api.polygon.io/v2/aggs/ticker/AAPL/range/1/minute/1640995200000/1662746159999?cursor=bGltaXQ9NTAwMDAmc29ydD1kZXNj
Request Headers: map[Accept-Encoding:[gzip] Authorization:[REDACTED] User-Agent:[Polygon.io GoClient/v1.11.0]]
Response Headers: map[Content-Encoding:[gzip] Content-Type:[application/json] Date:[Fri, 16 Jun 2023 16:51:20 GMT] Server:[nginx/1.19.2] Strict-Transport-Security:[max-age=15724800; includeSubDomains] Vary:[Accept-Encoding] X-Request-Id:[dd52e655b9293ec193581f2d411a0062]]
Request URL: https://api.polygon.io/v2/aggs/ticker/AAPL/range/1/minute/1640995200000/1654813499999?cursor=bGltaXQ9NTAwMDAmc29ydD1kZXNj
Request Headers: map[Accept-Encoding:[gzip] Authorization:[REDACTED] User-Agent:[Polygon.io GoClient/v1.11.0]]
Response Headers: map[Content-Encoding:[gzip] Content-Type:[application/json] Date:[Fri, 16 Jun 2023 16:51:21 GMT] Server:[nginx/1.19.2] Strict-Transport-Security:[max-age=15724800; includeSubDomains] Vary:[Accept-Encoding] X-Request-Id:[06ec6ca2536152caddc9e2281a1cee86]]
Request URL: https://api.polygon.io/v2/aggs/ticker/AAPL/range/1/minute/1640995200000/1647341939999?cursor=bGltaXQ9NTAwMDAmc29ydD1kZXNj
Request Headers: map[Accept-Encoding:[gzip] Authorization:[REDACTED] User-Agent:[Polygon.io GoClient/v1.11.0]]
Response Headers: map[Content-Encoding:[gzip] Content-Type:[application/json] Date:[Fri, 16 Jun 2023 16:51:22 GMT] Server:[nginx/1.19.2] Strict-Transport-Security:[max-age=15724800; includeSubDomains] Vary:[Accept-Encoding] X-Request-Id:[f0dee9f19981ca93efc465bf97e5865c]]
291150
```

Dumping the request url, request headers, and response headers can be extremely useful for figuring out what API you're talking, the params, and what server headers are (the x-request-id is really useful for support).