### PR TITLE
Added tests for exchanges, indicators, and splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-45.9%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-57.5%25-yellow)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/rest/models/exchanges_test.go
+++ b/rest/models/exchanges_test.go
@@ -1,0 +1,21 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestGetExchangesParams(t *testing.T) {
+	assetClass := models.AssetStocks
+	locale := models.US
+
+	expect := models.GetExchangesParams{
+		AssetClass: &assetClass,
+		Locale:     &locale,
+	}
+	actual := models.GetExchangesParams{}.
+		WithAssetClass(assetClass).
+		WithLocale(locale)
+	checkParams(t, expect, *actual)
+}

--- a/rest/models/exchanges_test.go
+++ b/rest/models/exchanges_test.go
@@ -9,7 +9,6 @@ import (
 func TestGetExchangesParams(t *testing.T) {
 	assetClass := models.AssetStocks
 	locale := models.US
-
 	expect := models.GetExchangesParams{
 		AssetClass: &assetClass,
 		Locale:     &locale,

--- a/rest/models/indicators_test.go
+++ b/rest/models/indicators_test.go
@@ -56,7 +56,6 @@ func TestGetEMAParams(t *testing.T) {
 	order := models.Asc
 	limit := 100
 	window := 5
-
 	expect := models.GetEMAParams{
 		Timespan:         &timespan,
 		TimestampEQ:      &timestamp,
@@ -97,7 +96,6 @@ func TestGetRSIParams(t *testing.T) {
 	order := models.Asc
 	limit := 100
 	window := 5
-
 	expect := models.GetRSIParams{
 		Timespan:         &timespan,
 		TimestampEQ:      &timestamp,
@@ -140,7 +138,6 @@ func TestGetMACDParams(t *testing.T) {
 	shortWindow := 12
 	longWindow := 26
 	signalWindow := 9
-
 	expect := models.GetMACDParams{
 		Timespan:         &timespan,
 		TimestampEQ:      &timestamp,

--- a/rest/models/indicators_test.go
+++ b/rest/models/indicators_test.go
@@ -1,0 +1,178 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestGetSMAParams(t *testing.T) {
+	timespan := models.Week
+	timestamp := models.Millis(time.Date(2022, 7, 25, 0, 0, 0, 0, time.UTC))
+	series := models.Close
+	expand := true
+	adjusted := true
+	order := models.Asc
+	limit := 100
+	window := 5
+
+	expect := models.GetSMAParams{
+		Timespan:         &timespan,
+		TimestampEQ:      &timestamp,
+		TimestampLT:      &timestamp,
+		TimestampLTE:     &timestamp,
+		TimestampGT:      &timestamp,
+		TimestampGTE:     &timestamp,
+		SeriesType:       &series,
+		ExpandUnderlying: &expand,
+		Adjusted:         &adjusted,
+		Order:            &order,
+		Limit:            &limit,
+		Window:           &window,
+	}
+	actual := models.GetSMAParams{}.
+		WithTimespan(timespan).
+		WithTimestamp(models.EQ, timestamp).
+		WithTimestamp(models.LT, timestamp).
+		WithTimestamp(models.LTE, timestamp).
+		WithTimestamp(models.GT, timestamp).
+		WithTimestamp(models.GTE, timestamp).
+		WithSeriesType(series).
+		WithExpandUnderlying(expand).
+		WithAdjusted(adjusted).
+		WithOrder(order).
+		WithLimit(limit).
+		WithWindow(window)
+
+	checkParams(t, expect, *actual)
+}
+
+func TestGetEMAParams(t *testing.T) {
+	timespan := models.Week
+	timestamp := models.Millis(time.Date(2022, 7, 25, 0, 0, 0, 0, time.UTC))
+	series := models.Close
+	expand := true
+	adjusted := true
+	order := models.Asc
+	limit := 100
+	window := 5
+
+	expect := models.GetEMAParams{
+		Timespan:         &timespan,
+		TimestampEQ:      &timestamp,
+		TimestampLT:      &timestamp,
+		TimestampLTE:     &timestamp,
+		TimestampGT:      &timestamp,
+		TimestampGTE:     &timestamp,
+		SeriesType:       &series,
+		ExpandUnderlying: &expand,
+		Adjusted:         &adjusted,
+		Order:            &order,
+		Limit:            &limit,
+		Window:           &window,
+	}
+	actual := models.GetEMAParams{}.
+		WithTimespan(timespan).
+		WithTimestamp(models.EQ, timestamp).
+		WithTimestamp(models.LT, timestamp).
+		WithTimestamp(models.LTE, timestamp).
+		WithTimestamp(models.GT, timestamp).
+		WithTimestamp(models.GTE, timestamp).
+		WithSeriesType(series).
+		WithExpandUnderlying(expand).
+		WithAdjusted(adjusted).
+		WithOrder(order).
+		WithLimit(limit).
+		WithWindow(window)
+
+	checkParams(t, expect, *actual)
+}
+
+func TestGetRSIParams(t *testing.T) {
+	timespan := models.Week
+	timestamp := models.Millis(time.Date(2022, 7, 25, 0, 0, 0, 0, time.UTC))
+	series := models.Close
+	expand := true
+	adjusted := true
+	order := models.Asc
+	limit := 100
+	window := 5
+
+	expect := models.GetRSIParams{
+		Timespan:         &timespan,
+		TimestampEQ:      &timestamp,
+		TimestampLT:      &timestamp,
+		TimestampLTE:     &timestamp,
+		TimestampGT:      &timestamp,
+		TimestampGTE:     &timestamp,
+		SeriesType:       &series,
+		ExpandUnderlying: &expand,
+		Adjusted:         &adjusted,
+		Order:            &order,
+		Limit:            &limit,
+		Window:           &window,
+	}
+	actual := models.GetRSIParams{}.
+		WithTimespan(timespan).
+		WithTimestamp(models.EQ, timestamp).
+		WithTimestamp(models.LT, timestamp).
+		WithTimestamp(models.LTE, timestamp).
+		WithTimestamp(models.GT, timestamp).
+		WithTimestamp(models.GTE, timestamp).
+		WithSeriesType(series).
+		WithExpandUnderlying(expand).
+		WithAdjusted(adjusted).
+		WithOrder(order).
+		WithLimit(limit).
+		WithWindow(window)
+
+	checkParams(t, expect, *actual)
+}
+
+func TestGetMACDParams(t *testing.T) {
+	timespan := models.Week
+	timestamp := models.Millis(time.Date(2022, 7, 25, 0, 0, 0, 0, time.UTC))
+	series := models.Close
+	expand := true
+	adjusted := true
+	order := models.Asc
+	limit := 100
+	shortWindow := 12
+	longWindow := 26
+	signalWindow := 9
+
+	expect := models.GetMACDParams{
+		Timespan:         &timespan,
+		TimestampEQ:      &timestamp,
+		TimestampLT:      &timestamp,
+		TimestampLTE:     &timestamp,
+		TimestampGT:      &timestamp,
+		TimestampGTE:     &timestamp,
+		SeriesType:       &series,
+		ExpandUnderlying: &expand,
+		Adjusted:         &adjusted,
+		Order:            &order,
+		Limit:            &limit,
+		ShortWindow:      &shortWindow,
+		LongWindow:       &longWindow,
+		SignalWindow:     &signalWindow,
+	}
+	actual := models.GetMACDParams{}.
+		WithTimespan(timespan).
+		WithTimestamp(models.EQ, timestamp).
+		WithTimestamp(models.LT, timestamp).
+		WithTimestamp(models.LTE, timestamp).
+		WithTimestamp(models.GT, timestamp).
+		WithTimestamp(models.GTE, timestamp).
+		WithSeriesType(series).
+		WithExpandUnderlying(expand).
+		WithAdjusted(adjusted).
+		WithOrder(order).
+		WithLimit(limit).
+		WithShortWindow(shortWindow).
+		WithLongWindow(longWindow).
+		WithSignalWindow(signalWindow)
+
+	checkParams(t, expect, *actual)
+}

--- a/rest/models/indicators_test.go
+++ b/rest/models/indicators_test.go
@@ -16,7 +16,6 @@ func TestGetSMAParams(t *testing.T) {
 	order := models.Asc
 	limit := 100
 	window := 5
-
 	expect := models.GetSMAParams{
 		Timespan:         &timespan,
 		TimestampEQ:      &timestamp,

--- a/rest/models/splits_test.go
+++ b/rest/models/splits_test.go
@@ -14,7 +14,6 @@ func TestListSplitsParams(t *testing.T) {
 	sort := models.TickerSymbol
 	order := models.Asc
 	limit := 100
-
 	expect := models.ListSplitsParams{
 		TickerEQ:         &ticker,
 		TickerLT:         &ticker,

--- a/rest/models/splits_test.go
+++ b/rest/models/splits_test.go
@@ -1,0 +1,51 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestListSplitsParams(t *testing.T) {
+	ticker := "A"
+	date := models.Date(time.Date(2023, 3, 23, 0, 0, 0, 0, time.Local))
+	reverseSplit := true
+	sort := models.TickerSymbol
+	order := models.Asc
+	limit := 100
+
+	expect := models.ListSplitsParams{
+		TickerEQ:         &ticker,
+		TickerLT:         &ticker,
+		TickerLTE:        &ticker,
+		TickerGT:         &ticker,
+		TickerGTE:        &ticker,
+		ExecutionDateEQ:  &date,
+		ExecutionDateLT:  &date,
+		ExecutionDateLTE: &date,
+		ExecutionDateGT:  &date,
+		ExecutionDateGTE: &date,
+		ReverseSplit:     &reverseSplit,
+		Sort:             &sort,
+		Order:            &order,
+		Limit:            &limit,
+	}
+	actual := models.ListSplitsParams{}.
+		WithTicker(models.EQ, ticker).
+		WithTicker(models.LT, ticker).
+		WithTicker(models.LTE, ticker).
+		WithTicker(models.GT, ticker).
+		WithTicker(models.GTE, ticker).
+		WithExecutionDate(models.EQ, date).
+		WithExecutionDate(models.LT, date).
+		WithExecutionDate(models.LTE, date).
+		WithExecutionDate(models.GT, date).
+		WithExecutionDate(models.GTE, date).
+		WithReverseSplit(reverseSplit).
+		WithSort(sort).
+		WithOrder(order).
+		WithLimit(limit)
+
+	checkParams(t, expect, *actual)
+}


### PR DESCRIPTION
Added more tests to get us on the path to the 80% coverage mark. This is so we can be added to the https://github.com/avelino/awesome-go#third-party-apis list.