### PR TITLE
Added tests for dividends, financials, trades, quotes, and tickers (recreate of 335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-57.5%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-72.9%25-brightgreen)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/rest/models/dividends_test.go
+++ b/rest/models/dividends_test.go
@@ -1,0 +1,75 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestListDividendsParams(t *testing.T) {
+	ticker := "A"
+	date := models.Date(time.Date(2023, 3, 23, 0, 0, 0, 0, time.Local))
+	cash := 1.25
+	frequency := models.Annually
+	dividendType := models.DividendCD
+	order := models.Asc
+	limit := 100
+	sort := models.TickerSymbol
+
+	expect := models.ListDividendsParams{
+		TickerEQ:           &ticker,
+		TickerLT:           &ticker,
+		TickerLTE:          &ticker,
+		TickerGT:           &ticker,
+		TickerGTE:          &ticker,
+		ExDividendDateEQ:   &date,
+		ExDividendDateLT:   &date,
+		ExDividendDateLTE:  &date,
+		ExDividendDateGT:   &date,
+		ExDividendDateGTE:  &date,
+		DeclarationDateEQ:  &date,
+		DeclarationDateLT:  &date,
+		DeclarationDateLTE: &date,
+		DeclarationDateGT:  &date,
+		DeclarationDateGTE: &date,
+		CashAmountEQ:       &cash,
+		CashAmountLT:       &cash,
+		CashAmountLTE:      &cash,
+		CashAmountGT:       &cash,
+		CashAmountGTE:      &cash,
+		Frequency:          &frequency,
+		DividendType:       &dividendType,
+		Order:              &order,
+		Limit:              &limit,
+		Sort:               &sort,
+	}
+	actual := models.ListDividendsParams{}.
+		WithTicker(models.EQ, ticker).
+		WithTicker(models.LT, ticker).
+		WithTicker(models.LTE, ticker).
+		WithTicker(models.GT, ticker).
+		WithTicker(models.GTE, ticker).
+		WithExDividendDate(models.EQ, date).
+		WithExDividendDate(models.LT, date).
+		WithExDividendDate(models.LTE, date).
+		WithExDividendDate(models.GT, date).
+		WithExDividendDate(models.GTE, date).
+		WithDeclarationDate(models.EQ, date).
+		WithDeclarationDate(models.LT, date).
+		WithDeclarationDate(models.LTE, date).
+		WithDeclarationDate(models.GT, date).
+		WithDeclarationDate(models.GTE, date).
+		WithCashAmount(models.EQ, cash).
+		WithCashAmount(models.LT, cash).
+		WithCashAmount(models.LTE, cash).
+		WithCashAmount(models.GT, cash).
+		WithCashAmount(models.GTE, cash).
+		WithFrequency(models.Annually).
+		WithDividendType(models.DividendCD).
+		WithOrder(order).
+		WithLimit(limit).
+		WithSort(sort)
+
+	checkParams(t, expect, *actual)
+}

--- a/rest/models/dividends_test.go
+++ b/rest/models/dividends_test.go
@@ -16,7 +16,6 @@ func TestListDividendsParams(t *testing.T) {
 	order := models.Asc
 	limit := 100
 	sort := models.TickerSymbol
-
 	expect := models.ListDividendsParams{
 		TickerEQ:           &ticker,
 		TickerLT:           &ticker,

--- a/rest/models/financials_test.go
+++ b/rest/models/financials_test.go
@@ -1,0 +1,67 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestListStockFinancialsParams(t *testing.T) {
+	ticker := "A"
+	date := models.Date(time.Date(2023, 3, 23, 0, 0, 0, 0, time.Local))
+	timeframe := models.TFAnnual
+	cik := "0001650729"
+	name := "Apple"
+	sic := "3570"
+	sources := false
+	order := models.Asc
+	limit := 100
+	sort := models.TickerSymbol
+
+	expect := models.ListStockFinancialsParams{
+		Ticker:                &ticker,
+		CIK:                   &cik,
+		CompanyNameFull:       &name,
+		CompanyNameSearch:     &name,
+		SIC:                   &sic,
+		FilingDateEQ:          &date,
+		FilingDateLT:          &date,
+		FilingDateLTE:         &date,
+		FilingDateGT:          &date,
+		FilingDateGTE:         &date,
+		PeriodOfReportDateEQ:  &date,
+		PeriodOfReportDateLT:  &date,
+		PeriodOfReportDateLTE: &date,
+		PeriodOfReportDateGT:  &date,
+		PeriodOfReportDateGTE: &date,
+		Timeframe:             &timeframe,
+		IncludeSources:        &sources,
+		Order:                 &order,
+		Limit:                 &limit,
+		Sort:                  &sort,
+	}
+	actual := models.ListStockFinancialsParams{}.
+		WithTicker(ticker).
+		WithCIK(cik).
+		WithCompanyName(models.Full, name).
+		WithCompanyName(models.Search, name).
+		WithSIC(sic).
+		WithFilingDate(models.EQ, date).
+		WithFilingDate(models.LT, date).
+		WithFilingDate(models.LTE, date).
+		WithFilingDate(models.GT, date).
+		WithFilingDate(models.GTE, date).
+		WithPeriodOfReportDate(models.EQ, date).
+		WithPeriodOfReportDate(models.LT, date).
+		WithPeriodOfReportDate(models.LTE, date).
+		WithPeriodOfReportDate(models.GT, date).
+		WithPeriodOfReportDate(models.GTE, date).
+		WithTimeframe(timeframe).
+		WithIncludeSources(sources).
+		WithOrder(order).
+		WithLimit(limit).
+		WithSort(sort)
+
+	checkParams(t, expect, *actual)
+}

--- a/rest/models/quotes_test.go
+++ b/rest/models/quotes_test.go
@@ -1,0 +1,37 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestListQuotesParams(t *testing.T) {
+	timestamp := models.Nanos(time.Date(2023, 3, 23, 0, 0, 0, 0, time.UTC))
+	order := models.Asc
+	limit := 100
+	sort := models.Timestamp
+
+	expect := models.ListQuotesParams{
+		TimestampEQ:  &timestamp,
+		TimestampLT:  &timestamp,
+		TimestampLTE: &timestamp,
+		TimestampGT:  &timestamp,
+		TimestampGTE: &timestamp,
+		Order:        &order,
+		Limit:        &limit,
+		Sort:         &sort,
+	}
+	actual := models.ListQuotesParams{}.
+		WithTimestamp(models.EQ, timestamp).
+		WithTimestamp(models.LT, timestamp).
+		WithTimestamp(models.LTE, timestamp).
+		WithTimestamp(models.GT, timestamp).
+		WithTimestamp(models.GTE, timestamp).
+		WithOrder(order).
+		WithLimit(limit).
+		WithSort(sort)
+
+	checkParams(t, expect, *actual)
+}

--- a/rest/models/tickers_test.go
+++ b/rest/models/tickers_test.go
@@ -1,0 +1,132 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestListTickersParams(t *testing.T) {
+	ticker := "A"
+	assetType := "CS"
+	assetMarket := models.AssetStocks
+	cik := 1650729
+	name := "Apple"
+	date := models.Date(time.Date(2023, 3, 23, 0, 0, 0, 0, time.Local))
+	active := true
+	sort := models.TickerSymbol
+	order := models.Asc
+	limit := 100
+
+	expect := models.ListTickersParams{
+		TickerEQ:  &ticker,
+		TickerLT:  &ticker,
+		TickerLTE: &ticker,
+		TickerGT:  &ticker,
+		TickerGTE: &ticker,
+		Type:      &assetType,
+		Market:    &assetMarket,
+		CIK:       &cik,
+		Search:    &name,
+		Date:      &date,
+		Active:    &active,
+		Sort:      &sort,
+		Order:     &order,
+		Limit:     &limit,
+	}
+	actual := models.ListTickersParams{}.
+		WithTicker(models.EQ, ticker).
+		WithTicker(models.LT, ticker).
+		WithTicker(models.LTE, ticker).
+		WithTicker(models.GT, ticker).
+		WithTicker(models.GTE, ticker).
+		WithType(assetType).
+		WithMarket(assetMarket).
+		WithCIK(cik).
+		WithSearch(name).
+		WithDate(date).
+		WithActive(active).
+		WithSort(sort).
+		WithOrder(order).
+		WithLimit(limit)
+
+	checkParams(t, expect, *actual)
+}
+
+func TestGetTickerDetailsParams(t *testing.T) {
+	date := models.Date(time.Date(2023, 3, 23, 0, 0, 0, 0, time.Local))
+
+	expect := models.GetTickerDetailsParams{
+		Date: &date,
+	}
+	actual := models.GetTickerDetailsParams{}.
+		WithDate(date)
+
+	checkParams(t, expect, *actual)
+}
+
+func TestListTickerNewsParams(t *testing.T) {
+	ticker := "A"
+	date := models.Millis(time.Date(2022, 7, 25, 0, 0, 0, 0, time.UTC))
+	sort := models.TickerSymbol
+	order := models.Asc
+	limit := 100
+
+	expect := models.ListTickerNewsParams{
+		TickerEQ:        &ticker,
+		TickerLT:        &ticker,
+		TickerLTE:       &ticker,
+		TickerGT:        &ticker,
+		TickerGTE:       &ticker,
+		PublishedUtcEQ:  &date,
+		PublishedUtcLT:  &date,
+		PublishedUtcLTE: &date,
+		PublishedUtcGT:  &date,
+		PublishedUtcGTE: &date,
+		Sort:            &sort,
+		Order:           &order,
+		Limit:           &limit,
+	}
+	actual := models.ListTickerNewsParams{}.
+		WithTicker(models.EQ, ticker).
+		WithTicker(models.LT, ticker).
+		WithTicker(models.LTE, ticker).
+		WithTicker(models.GT, ticker).
+		WithTicker(models.GTE, ticker).
+		WithPublishedUTC(models.EQ, date).
+		WithPublishedUTC(models.LT, date).
+		WithPublishedUTC(models.LTE, date).
+		WithPublishedUTC(models.GT, date).
+		WithPublishedUTC(models.GTE, date).
+		WithSort(sort).
+		WithOrder(order).
+		WithLimit(limit)
+
+	checkParams(t, expect, *actual)
+}
+
+func TestGetTickerTypesParams(t *testing.T) {
+	assetClass := models.AssetStocks
+	locale := models.US
+
+	expect := models.GetTickerTypesParams{
+		AssetClass: &assetClass,
+		Locale:     &locale,
+	}
+	actual := models.GetTickerTypesParams{}.
+		WithAssetClass(assetClass).
+		WithLocale(locale)
+	checkParams(t, expect, *actual)
+}
+
+func TestGetTickerEventsParams(t *testing.T) {
+	types := "ticker_change"
+	expect := models.GetTickerEventsParams{
+		Types: &types,
+	}
+	actual := models.GetTickerEventsParams{}.
+		WithTypes(types)
+
+	checkParams(t, expect, *actual)
+}

--- a/rest/models/trades_test.go
+++ b/rest/models/trades_test.go
@@ -1,0 +1,37 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/polygon-io/client-go/rest/models"
+)
+
+func TestListTradesParams(t *testing.T) {
+	timestamp := models.Nanos(time.Date(2023, 3, 23, 0, 0, 0, 0, time.UTC))
+	order := models.Asc
+	limit := 100
+	sort := models.Timestamp
+
+	expect := models.ListTradesParams{
+		TimestampEQ:  &timestamp,
+		TimestampLT:  &timestamp,
+		TimestampLTE: &timestamp,
+		TimestampGT:  &timestamp,
+		TimestampGTE: &timestamp,
+		Order:        &order,
+		Limit:        &limit,
+		Sort:         &sort,
+	}
+	actual := models.ListTradesParams{}.
+		WithTimestamp(models.EQ, timestamp).
+		WithTimestamp(models.LT, timestamp).
+		WithTimestamp(models.LTE, timestamp).
+		WithTimestamp(models.GT, timestamp).
+		WithTimestamp(models.GTE, timestamp).
+		WithOrder(order).
+		WithLimit(limit).
+		WithSort(sort)
+
+	checkParams(t, expect, *actual)
+}


### PR DESCRIPTION
Re-created PR. The coverage github action seems extremely picky and appears to only look at the first commit within a PR. So, if there are any issues it blocks even if you fix with additional commits. So, I'm stuck recreating here. I'll check out the issue in more detail but recreated to get these changes in.