### PR TITLE
Added tests for params with only required fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-77.0%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-77.2%25-brightgreen)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/rest/models/snapshot_test.go
+++ b/rest/models/snapshot_test.go
@@ -88,3 +88,165 @@ func TestListOptionsChainParams(t *testing.T) {
 
 	checkParams(t, expect, *actual)
 }
+
+func TestGetTickerSnapshotParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		params models.GetTickerSnapshotParams
+		want   string
+	}{
+		{
+			name:   "All fields valid",
+			params: models.GetTickerSnapshotParams{Locale: models.US, MarketType: models.Stocks, Ticker: "AAPL"},
+			want:   "",
+		},
+		{
+			name:   "Missing Locale",
+			params: models.GetTickerSnapshotParams{MarketType: models.Stocks, Ticker: "AAPL"},
+			want:   "Locale is required",
+		},
+		{
+			name:   "Missing MarketType",
+			params: models.GetTickerSnapshotParams{Locale: models.US, Ticker: "AAPL"},
+			want:   "MarketType is required",
+		},
+		{
+			name:   "Missing Ticker",
+			params: models.GetTickerSnapshotParams{Locale: models.US, MarketType: models.Stocks},
+			want:   "Ticker is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := ""
+			if tt.params.Locale == "" {
+				errMsg = "Locale is required"
+			} else if tt.params.MarketType == "" {
+				errMsg = "MarketType is required"
+			} else if tt.params.Ticker == "" {
+				errMsg = "Ticker is required"
+			}
+
+			if errMsg != tt.want {
+				t.Errorf("Expected error: '%s', but got: '%s'", tt.want, errMsg)
+			}
+		})
+	}
+}
+
+func TestGetGainersLosersSnapshotParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		params models.GetGainersLosersSnapshotParams
+		want   string
+	}{
+		{
+			name:   "All fields valid",
+			params: models.GetGainersLosersSnapshotParams{Locale: models.US, MarketType: models.Stocks, Direction: models.Gainers},
+			want:   "",
+		},
+		{
+			name:   "Missing Locale",
+			params: models.GetGainersLosersSnapshotParams{MarketType: models.Stocks, Direction: models.Gainers},
+			want:   "Locale is required",
+		},
+		{
+			name:   "Missing MarketType",
+			params: models.GetGainersLosersSnapshotParams{Locale: models.US, Direction: models.Losers},
+			want:   "MarketType is required",
+		},
+		{
+			name:   "Missing Direction",
+			params: models.GetGainersLosersSnapshotParams{Locale: models.US, MarketType: models.Stocks},
+			want:   "Direction is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := ""
+			if tt.params.Locale == "" {
+				errMsg = "Locale is required"
+			} else if tt.params.MarketType == "" {
+				errMsg = "MarketType is required"
+			} else if tt.params.Direction == "" {
+				errMsg = "Direction is required"
+			}
+
+			if errMsg != tt.want {
+				t.Errorf("Expected error: '%s', but got: '%s'", tt.want, errMsg)
+			}
+		})
+	}
+}
+
+func TestGetOptionContractSnapshotParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		params models.GetOptionContractSnapshotParams
+		want   string
+	}{
+		{
+			name:   "All fields valid",
+			params: models.GetOptionContractSnapshotParams{UnderlyingAsset: "EVRI", OptionContract: "O:EVRI240119C00002500"},
+			want:   "",
+		},
+		{
+			name:   "Missing UnderlyingAsset",
+			params: models.GetOptionContractSnapshotParams{OptionContract: "O:EVRI240119C00002500"},
+			want:   "UnderlyingAsset is required",
+		},
+		{
+			name:   "Missing OptionContract",
+			params: models.GetOptionContractSnapshotParams{UnderlyingAsset: "EVRI"},
+			want:   "OptionContract is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := ""
+			if tt.params.UnderlyingAsset == "" {
+				errMsg = "UnderlyingAsset is required"
+			} else if tt.params.OptionContract == "" {
+				errMsg = "OptionContract is required"
+			}
+
+			if errMsg != tt.want {
+				t.Errorf("Expected error: '%s', but got: '%s'", tt.want, errMsg)
+			}
+		})
+	}
+}
+
+func TestGetCryptoFullBookSnapshotParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		params models.GetCryptoFullBookSnapshotParams
+		want   string
+	}{
+		{
+			name:   "Valid Ticker",
+			params: models.GetCryptoFullBookSnapshotParams{Ticker: "X:BTCUSD"},
+			want:   "",
+		},
+		{
+			name:   "Missing Ticker",
+			params: models.GetCryptoFullBookSnapshotParams{},
+			want:   "Ticker is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := ""
+			if tt.params.Ticker == "" {
+				errMsg = "Ticker is required"
+			}
+
+			if errMsg != tt.want {
+				t.Errorf("Expected error: '%s', but got: '%s'", tt.want, errMsg)
+			}
+		})
+	}
+}

--- a/rest/models/snapshot_test.go
+++ b/rest/models/snapshot_test.go
@@ -135,6 +135,17 @@ func TestGetTickerSnapshotParams(t *testing.T) {
 	}
 }
 
+func TestGetGainersLosersSnapshotParamsOTC(t *testing.T) {
+	otc := false
+	expect := models.GetGainersLosersSnapshotParams{
+		IncludeOTC: &otc,
+	}
+	actual := models.GetGainersLosersSnapshotParams{}.
+		WithIncludeOTC(otc)
+
+	checkParams(t, expect, *actual)
+}
+
 func TestGetGainersLosersSnapshotParams(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/rest/models/snapshot_test.go
+++ b/rest/models/snapshot_test.go
@@ -248,6 +248,7 @@ func TestGetCryptoFullBookSnapshotParams(t *testing.T) {
 			want:   "Ticker is required",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			errMsg := ""


### PR DESCRIPTION
Added tests for a couple snapshot endpoints where there are only required fields. This needed a different type of test just to make sure we're passing the correct required things, like ticker, market, etc.