### PR TITLE
change sequence number from nanos to int in quotes responses

### DIFF
--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/polygon-io/client-go/rest/models"
 )
 
-const clientVersion = "v1.15.0"
+const clientVersion = "v1.16.0"
 
 const (
 	APIURL            = "https://api.polygon.io"

--- a/rest/models/quotes.go
+++ b/rest/models/quotes.go
@@ -123,7 +123,7 @@ type Quote struct {
 	Conditions           []int32 `json:"conditions,omitempty"`
 	Indicators           []int32 `json:"indicators,omitempty"`
 	ParticipantTimestamp Nanos   `json:"participant_timestamp,omitempty"`
-	SequenceNumber       Nanos   `json:"sequence_number,omitempty"`
+	SequenceNumber       int64   `json:"sequence_number,omitempty"`
 	SipTimestamp         Nanos   `json:"sip_timestamp,omitempty"`
 	Tape                 int32   `json:"tape,omitempty"`
 	TrfTimestamp         Nanos   `json:"trf_timestamp,omitempty"`
@@ -133,7 +133,7 @@ type Quote struct {
 type LastQuote struct {
 	Ticker               string  `json:"T,omitempty"`
 	TrfTimestamp         Nanos   `json:"f,omitempty"`
-	SequenceNumber       Nanos   `json:"q,omitempty"`
+	SequenceNumber       int64   `json:"q,omitempty"`
 	SipTimestamp         Nanos   `json:"t,omitempty"`
 	ParticipantTimestamp Nanos   `json:"y,omitempty"`
 	AskPrice             float64 `json:"P,omitempty"`


### PR DESCRIPTION
This looks like a mistake in two of our quotes response types (see the [docs](https://polygon.io/docs/stocks/get_v3_quotes__stockticker)). It's a breaking change and will need to be called out in the release notes. I'll take care of that once the fix is merged.