### PR TITLE
Bug fix for FMV with stocks, options, forex, or crypto

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,14 +17,14 @@ jobs:
     name: golangci-lint
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52
+          version: v1.54
       - name: gofmt
         run: |
           go fmt ./...

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -82,16 +82,21 @@ const (
 )
 
 func (m Market) supports(topic Topic) bool {
+	// FMV is supported for Stocks, Options, Forex, and Crypto but is not within the range
+	// so we need to make sure FMV is suppored if these markets are used.
+	isBusinessFairMarketValue := topic == BusinessFairMarketValue
+
 	switch m {
 	case Stocks:
-		return topic > stocksMin && topic < stocksMax
+		return isBusinessFairMarketValue || (topic > stocksMin && topic < stocksMax)
 	case Options:
-		return topic > optionsMin && topic < optionsMax
+		return isBusinessFairMarketValue || (topic > optionsMin && topic < optionsMax)
 	case Forex:
-		return topic > forexMin && topic < forexMax
+		return isBusinessFairMarketValue || (topic > forexMin && topic < forexMax)
 	case Crypto:
-		return topic > cryptoMin && topic < cryptoMax
+		return isBusinessFairMarketValue || (topic > cryptoMin && topic < cryptoMax)
 	}
+
 	return true // assume user knows what they're doing if they use some unknown market
 }
 


### PR DESCRIPTION
This PR addresses a bug related to the support of `BusinessFairMarketValue` (`FMV`) in different market types. Previously, our supports function in the Market type only checked if a topic was within predefined min-max ranges for each market type (Stocks, Options, Forex, Crypto). This implementation did not account for FMV, which falls outside these ranges but is relevant and essential for these market types.

Changes Made:

- Modified the supports function to include a check for BusinessFairMarketValue.
- Ensured FMV is now supported for Stocks, Options, Forex, and Crypto markets.
- Added a clarifying comment in the code to explain the rationale behind the additional check for FMV.

Impact:

- This fix allows FMV to be recognized as a supported topic in the relevant market types, aligning the functionality with our intended feature set.


Here's a text script:

```go
package main

import (
	"os"
	"os/signal"

	polygonws "github.com/polygon-io/client-go/websocket"
	"github.com/polygon-io/client-go/websocket/models"
	"github.com/sirupsen/logrus"
)

func main() {
	log := logrus.New()
	log.SetLevel(logrus.DebugLevel)
	log.SetFormatter(&logrus.JSONFormatter{})
	c, err := polygonws.New(polygonws.Config{
		APIKey: os.Getenv("POLYGON_API_KEY"),
		Feed:   polygonws.BusinessFeed,
		Market: polygonws.Stocks,
		Log:    log,
	})
	if err != nil {
		log.Fatal(err)
	}
	defer c.Close()

	// FMV
	_ = c.Subscribe(polygonws.BusinessFairMarketValue, "*")

	if err := c.Connect(); err != nil {
		log.Error(err)
		return
	}

	sigint := make(chan os.Signal, 1)
	signal.Notify(sigint, os.Interrupt)

	for {
		select {
		case <-sigint:
			return
		case <-c.Error():
			return
		case out, more := <-c.Output():
			if !more {
				return
			}
			switch out.(type) {
			case models.FairMarketValue:
				log.WithFields(logrus.Fields{"fmv": out}).Info()
			default:
				log.WithFields(logrus.Fields{"unknown": out}).Info()
			}
		}
	}
}
```