### PR TITLE
Added FMV messages to output channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-76.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-76.6%25-brightgreen)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/websocket/example/fmv/main.go
+++ b/websocket/example/fmv/main.go
@@ -48,7 +48,8 @@ func main() {
 			switch out.(type) {
 			case models.FairMarketValue:
 				log.WithFields(logrus.Fields{"fmv": out}).Info()
-			default:
+
+				default:
 				log.WithFields(logrus.Fields{"unknown": out}).Info()
 			}
 		}

--- a/websocket/example/fmv/main.go
+++ b/websocket/example/fmv/main.go
@@ -49,7 +49,7 @@ func main() {
 			case models.FairMarketValue:
 				log.WithFields(logrus.Fields{"fmv": out}).Info()
 
-				default:
+			default:
 				log.WithFields(logrus.Fields{"unknown": out}).Info()
 			}
 		}

--- a/websocket/example/fmv/main.go
+++ b/websocket/example/fmv/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+
+	polygonws "github.com/polygon-io/client-go/websocket"
+	"github.com/polygon-io/client-go/websocket/models"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+	log.SetFormatter(&logrus.JSONFormatter{})
+	c, err := polygonws.New(polygonws.Config{
+		APIKey: os.Getenv("POLYGON_API_KEY"),
+		Feed:   polygonws.BusinessFeed,
+		Market: polygonws.Stocks,
+		Log:    log,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	// FMV
+	_ = c.Subscribe(polygonws.BusinessFairMarketValue, "*")
+
+	if err := c.Connect(); err != nil {
+		log.Error(err)
+		return
+	}
+
+	sigint := make(chan os.Signal, 1)
+	signal.Notify(sigint, os.Interrupt)
+
+	for {
+		select {
+		case <-sigint:
+			return
+		case <-c.Error():
+			return
+		case out, more := <-c.Output():
+			if !more {
+				return
+			}
+			switch out.(type) {
+			case models.FairMarketValue:
+				log.WithFields(logrus.Fields{"fmv": out}).Info()
+			default:
+				log.WithFields(logrus.Fields{"unknown": out}).Info()
+			}
+		}
+	}
+}

--- a/websocket/polygon.go
+++ b/websocket/polygon.go
@@ -550,6 +550,7 @@ func (c *Client) handleData(eventType string, msg json.RawMessage) {
 		if err := json.Unmarshal(msg, &out); err != nil {
 			c.log.Errorf("failed to unmarshal message: %v", err)
 		}
+		c.output <- out
 
 	default:
 		c.log.Infof("unknown message type '%s'", sanitize(eventType))


### PR DESCRIPTION
Fixed a bug where `FMV` event messages were not being sent to the output channel. Also added an example. This fixed a bug a customer is seeing.