### PR TITLE
Update options snapshot example with params

### DIFF
--- a/rest/example/options/snapshots-options-chain/main.go
+++ b/rest/example/options/snapshots-options-chain/main.go
@@ -19,8 +19,15 @@ func main() {
 
 	// set params
 	params := &models.ListOptionsChainParams{
-		UnderlyingAsset: "AAPL",
+	    UnderlyingAsset: "SPY",
+	    StrikePriceGTE:  new(float64),
+	    StrikePriceLTE:  new(float64),
+	    Limit:           new(int),
 	}
+
+	*params.StrikePriceGTE = 500.0
+	*params.StrikePriceLTE = 600.0
+	*params.Limit = 250
 
 	// make request
 	iter := c.ListOptionsChainSnapshot(context.Background(), params)

--- a/rest/example/options/snapshots-options-chain/main.go
+++ b/rest/example/options/snapshots-options-chain/main.go
@@ -19,10 +19,10 @@ func main() {
 
 	// set params
 	params := &models.ListOptionsChainParams{
-	    UnderlyingAsset: "SPY",
-	    StrikePriceGTE:  new(float64),
-	    StrikePriceLTE:  new(float64),
-	    Limit:           new(int),
+		UnderlyingAsset: "SPY",
+		StrikePriceGTE:  new(float64),
+		StrikePriceLTE:  new(float64),
+		Limit:           new(int),
 	}
 
 	*params.StrikePriceGTE = 500.0

--- a/rest/example/options/snapshots-options-chain/main.go
+++ b/rest/example/options/snapshots-options-chain/main.go
@@ -18,16 +18,12 @@ func main() {
 	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
 
 	// set params
-	params := &models.ListOptionsChainParams{
+	params := models.ListOptionsChainParams{
 		UnderlyingAsset: "SPY",
 		StrikePriceGTE:  new(float64),
 		StrikePriceLTE:  new(float64),
 		Limit:           new(int),
-	}
-
-	*params.StrikePriceGTE = 500.0
-	*params.StrikePriceLTE = 600.0
-	*params.Limit = 250
+	}.WithStrikePrice("gte", 500.00).WithStrikePrice("lte", 600.00).WithLimit(250)
 
 	// make request
 	iter := c.ListOptionsChainSnapshot(context.Background(), params)

--- a/rest/models/snapshot.go
+++ b/rest/models/snapshot.go
@@ -106,8 +106,23 @@ type ListOptionsChainParams struct {
 }
 
 // WithStrikePrice sets strike price to params. Strike Price is the price at which a put or call option can be exercised.
-func (o ListOptionsChainParams) WithStrikePrice(strikePrice float64) *ListOptionsChainParams {
-	o.StrikePrice = &strikePrice
+// comparator options include EQ, LT, LTE, GT, and GTE.
+// expirationDate should be in YYYY-MM-DD format
+func (o ListOptionsChainParams) WithStrikePrice(comparator Comparator, strikePrice float64) *ListOptionsChainParams {
+	switch comparator {
+	case EQ:
+		o.StrikePrice = &strikePrice
+	case LT:
+		o.StrikePriceLT = &strikePrice
+	case LTE:
+		o.StrikePriceLTE = &strikePrice
+	case GT:
+		o.StrikePriceGT = &strikePrice
+	case GTE:
+		o.StrikePriceGTE = &strikePrice
+	default:
+		o.StrikePrice = &strikePrice
+	}
 	return &o
 }
 

--- a/rest/models/snapshot_test.go
+++ b/rest/models/snapshot_test.go
@@ -64,6 +64,10 @@ func TestListOptionsChainParams(t *testing.T) {
 	order := models.Asc
 	expect := models.ListOptionsChainParams{
 		StrikePrice:       &strikePrice,
+		StrikePriceLT:     &strikePrice,
+		StrikePriceLTE:    &strikePrice,
+		StrikePriceGT:     &strikePrice,
+		StrikePriceGTE:    &strikePrice,
 		ContractType:      &contractType,
 		ExpirationDateEQ:  &date,
 		ExpirationDateLT:  &date,
@@ -75,7 +79,11 @@ func TestListOptionsChainParams(t *testing.T) {
 		Order:             &order,
 	}
 	actual := models.ListOptionsChainParams{}.
-		WithStrikePrice(strikePrice).
+		WithStrikePrice(models.EQ, strikePrice).
+		WithStrikePrice(models.LT, strikePrice).
+		WithStrikePrice(models.LTE, strikePrice).
+		WithStrikePrice(models.GT, strikePrice).
+		WithStrikePrice(models.GTE, strikePrice).
 		WithContractType(contractType).
 		WithExpirationDate(models.EQ, date).
 		WithExpirationDate(models.LT, date).


### PR DESCRIPTION
Support received a request to update the example with params so they could see an example of using a filter.