### PR TITLE
Update ListOptionsChainParams.WithStrikePrice to support comparators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-76.6%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-76.7%25-brightgreen)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/rest/example/options/snapshots-options-chain/main.go
+++ b/rest/example/options/snapshots-options-chain/main.go
@@ -25,7 +25,7 @@ func main() {
 		Limit:           new(int),
 	}.WithStrikePrice("gte", 500.00).WithStrikePrice("lte", 600.00).WithLimit(250)
 
-	// make request
+	// make the request
 	iter := c.ListOptionsChainSnapshot(context.Background(), params)
 
 	// do something with the result

--- a/rest/example/options/snapshots-options-chain/main.go
+++ b/rest/example/options/snapshots-options-chain/main.go
@@ -18,9 +18,12 @@ func main() {
 	c := polygon.New(os.Getenv("POLYGON_API_KEY"))
 
 	// set params
-	params := &models.ListOptionsChainParams{
-		UnderlyingAsset: "AAPL",
-	}
+	params := models.ListOptionsChainParams{
+		UnderlyingAsset: "SPY",
+		StrikePriceGTE:  new(float64),
+		StrikePriceLTE:  new(float64),
+		Limit:           new(int),
+	}.WithStrikePrice("gte", 500.00).WithStrikePrice("lte", 600.00).WithLimit(250)
 
 	// make request
 	iter := c.ListOptionsChainSnapshot(context.Background(), params)

--- a/rest/models/snapshot.go
+++ b/rest/models/snapshot.go
@@ -106,8 +106,23 @@ type ListOptionsChainParams struct {
 }
 
 // WithStrikePrice sets strike price to params. Strike Price is the price at which a put or call option can be exercised.
-func (o ListOptionsChainParams) WithStrikePrice(strikePrice float64) *ListOptionsChainParams {
-	o.StrikePrice = &strikePrice
+// comparator options include EQ, LT, LTE, GT, and GTE.
+// expirationDate should be in YYYY-MM-DD format
+func (o ListOptionsChainParams) WithStrikePrice(comparator Comparator, strikePrice float64) *ListOptionsChainParams {
+	switch comparator {
+	case EQ:
+		o.StrikePrice = &strikePrice
+	case LT:
+		o.StrikePriceLT = &strikePrice
+	case LTE:
+		o.StrikePriceLTE = &strikePrice
+	case GT:
+		o.StrikePriceGT = &strikePrice
+	case GTE:
+		o.StrikePriceGTE = &strikePrice
+	default:
+		o.StrikePrice = &strikePrice
+	}
 	return &o
 }
 

--- a/rest/models/snapshot_test.go
+++ b/rest/models/snapshot_test.go
@@ -64,6 +64,10 @@ func TestListOptionsChainParams(t *testing.T) {
 	order := models.Asc
 	expect := models.ListOptionsChainParams{
 		StrikePrice:       &strikePrice,
+		StrikePriceLT:     &strikePrice,
+		StrikePriceLTE:    &strikePrice,
+		StrikePriceGT:     &strikePrice,
+		StrikePriceGTE:    &strikePrice,
 		ContractType:      &contractType,
 		ExpirationDateEQ:  &date,
 		ExpirationDateLT:  &date,
@@ -75,7 +79,11 @@ func TestListOptionsChainParams(t *testing.T) {
 		Order:             &order,
 	}
 	actual := models.ListOptionsChainParams{}.
-		WithStrikePrice(strikePrice).
+		WithStrikePrice(models.EQ, strikePrice).
+		WithStrikePrice(models.LT, strikePrice).
+		WithStrikePrice(models.LTE, strikePrice).
+		WithStrikePrice(models.GT, strikePrice).
+		WithStrikePrice(models.GTE, strikePrice).
 		WithContractType(contractType).
 		WithExpirationDate(models.EQ, date).
 		WithExpirationDate(models.LT, date).


### PR DESCRIPTION
This is a breaking change to `models.ListOptionsChainParams.models.ListOptionsChainParams` that adds support for strike price comparators via things like `.WithStrikePrice("gte", 500.00)` and `WithStrikePrice("lte", 600.00)`. A customer wanted to filter using the additional params but couldn't figure out the example. So, I wanted to update the example and found that we didn't support this without directly modifying ListOptionsChainParams with a pointer.