### PR TITLE
Added WithPayDate method to ListDividendsParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-76.5%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-76.7%25-brightgreen)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/rest/models/dividends.go
+++ b/rest/models/dividends.go
@@ -111,6 +111,22 @@ func (p ListDividendsParams) WithDeclarationDate(c Comparator, q Date) *ListDivi
 	return &p
 }
 
+func (p ListDividendsParams) WithPayDate(c Comparator, q Date) *ListDividendsParams {
+	switch c {
+	case EQ:
+		p.PayDateEQ = &q
+	case LT:
+		p.PayDateLT = &q
+	case LTE:
+		p.PayDateLTE = &q
+	case GT:
+		p.PayDateGT = &q
+	case GTE:
+		p.PayDateGTE = &q
+	}
+	return &p
+}
+
 func (p ListDividendsParams) WithFrequency(q Frequency) *ListDividendsParams {
 	p.Frequency = &q
 	return &p

--- a/rest/models/dividends.go
+++ b/rest/models/dividends.go
@@ -111,7 +111,6 @@ func (p ListDividendsParams) WithDeclarationDate(c Comparator, q Date) *ListDivi
 	return &p
 }
 
-
 func (p ListDividendsParams) WithPayDate(c Comparator, q Date) *ListDividendsParams {
 	switch c {
 	case EQ:

--- a/rest/models/dividends.go
+++ b/rest/models/dividends.go
@@ -111,6 +111,7 @@ func (p ListDividendsParams) WithDeclarationDate(c Comparator, q Date) *ListDivi
 	return &p
 }
 
+
 func (p ListDividendsParams) WithPayDate(c Comparator, q Date) *ListDividendsParams {
 	switch c {
 	case EQ:

--- a/rest/models/dividends_test.go
+++ b/rest/models/dividends_test.go
@@ -32,6 +32,11 @@ func TestListDividendsParams(t *testing.T) {
 		DeclarationDateLTE: &date,
 		DeclarationDateGT:  &date,
 		DeclarationDateGTE: &date,
+		PayDateEQ:          &date,
+		PayDateLT:          &date,
+		PayDateLTE:         &date,
+		PayDateGT:          &date,
+		PayDateGTE:         &date,
 		CashAmountEQ:       &cash,
 		CashAmountLT:       &cash,
 		CashAmountLTE:      &cash,
@@ -59,6 +64,11 @@ func TestListDividendsParams(t *testing.T) {
 		WithDeclarationDate(models.LTE, date).
 		WithDeclarationDate(models.GT, date).
 		WithDeclarationDate(models.GTE, date).
+		WithPayDate(models.EQ, date).
+		WithPayDate(models.LT, date).
+		WithPayDate(models.LTE, date).
+		WithPayDate(models.GT, date).
+		WithPayDate(models.GTE, date).
 		WithCashAmount(models.EQ, cash).
 		WithCashAmount(models.LT, cash).
 		WithCashAmount(models.LTE, cash).


### PR DESCRIPTION
Fixes https://github.com/polygon-io/client-go/issues/425. Added helper vs manually changing ListDividendsParams.

This will enable the following:

```go
params := models.ListDividendsParams{}.WithPayDate(models.EQ, models.Date(date))
```