### PR TITLE
Added ticker news insights support

### DIFF
--- a/.polygon/rest.json
+++ b/.polygon/rest.json
@@ -18312,7 +18312,7 @@
         "operationId": "ListNews",
         "parameters": [
           {
-            "description": "Return results that contain this ticker.",
+            "description": "Specify a case-sensitive ticker symbol. For example, AAPL represents Apple Inc.",
             "in": "query",
             "name": "ticker",
             "schema": {
@@ -18496,52 +18496,35 @@
                   "request_id": "831afdb0b8078549fed053476984947a",
                   "results": [
                     {
-                      "amp_url": "https://amp.benzinga.com/amp/content/20784086",
-                      "article_url": "https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square",
-                      "author": "Rachit  Vats",
-                      "description": "\u003cp\u003eCathie Wood-led Ark Investment Management on Friday snapped up another 221,167 shares of the cryptocurrency exchange \u003cstrong\u003eCoinbase Global Inc \u003c/strong\u003e(NASDAQ \u003ca class=\"ticker\" href=\"https://www.benzinga.com/stock/coin#NASDAQ\"\u003eCOIN\u003c/a\u003e) worth about $64.49 million on the stock\u0026rsquo;s Friday\u0026rsquo;s dip and also its fourth-straight loss.\u003c/p\u003e\n\u003cp\u003eThe investment firm\u0026rsquo;s \u003cstrong\u003eArk Innovation ETF\u003c/strong\u003e (NYSE \u003ca class=\" ticker\" href=\"https://www.benzinga.com/stock/arkk#NYSE\"\u003eARKK\u003c/a\u003e) bought the shares of the company that closed 0.63% lower at $291.60 on Friday, giving the cryptocurrency exchange a market cap of $58.09 billion. Coinbase\u0026rsquo;s market cap has dropped from $85.8 billion on its blockbuster listing earlier this month.\u003c/p\u003e\n\u003cp\u003eThe New York-based company also added another 3,873 shares of the mobile gaming company \u003cstrong\u003eSkillz Inc\u003c/strong\u003e (NYSE \u003ca class=\" ticker\" href=\"https://www.benzinga.com/stock/sklz#NYSE\"\u003eSKLZ\u003c/a\u003e), \u003ca href=\"http://www.benzinga.com/markets/cryptocurrency/21/04/20762794/cathie-woods-ark-loads-up-another-1-2-million-shares-in-skillz-also-adds-coinbase-draftkin\" \u003ejust a day after\u003c/a\u003e snapping 1.2 million shares of the stock.\u003c/p\u003e\n \u003cp\u003eARKK bought the shares of the company which closed ...\u003c/p\u003e\u003cp\u003e\u003ca href=https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square alt=Cathie Wood Adds More Coinbase, Skillz, Trims Square\u003eFull story available on Benzinga.com\u003c/a\u003e\u003c/p\u003e",
-                      "id": "nJsSJJdwViHZcw5367rZi7_qkXLfMzacXBfpv-vD9UA",
-                      "image_url": "https://cdn2.benzinga.com/files/imagecache/og_image_social_share_1200x630/images/story/2012/andre-francois-mckenzie-auhr4gcqcce-unsplash.jpg?width=720",
-                      "keywords": [
-                        "Sector ETFs",
-                        "Penny Stocks",
-                        "Cryptocurrency",
-                        "Small Cap",
-                        "Markets",
-                        "Trading Ideas",
-                        "ETFs"
+                      "amp_url": "https://m.uk.investing.com/news/stock-market-news/markets-are-underestimating-fed-cuts-ubs-3559968?ampMode=1",
+                      "article_url": "https://uk.investing.com/news/stock-market-news/markets-are-underestimating-fed-cuts-ubs-3559968",
+                      "author": "Sam Boughedda",
+                      "description": "UBS analysts warn that markets are underestimating the extent of future interest rate cuts by the Federal Reserve, as the weakening economy is likely to justify more cuts than currently anticipated.",
+                      "id": "8ec638777ca03b553ae516761c2a22ba2fdd2f37befae3ab6fdab74e9e5193eb",
+                      "image_url": "https://i-invdn-com.investing.com/news/LYNXNPEC4I0AL_L.jpg",
+                      "insights": [
+                        {
+                          "sentiment": "positive",
+                          "sentiment_reasoning": "UBS analysts are providing a bullish outlook on the extent of future Federal Reserve rate cuts, suggesting that markets are underestimating the number of cuts that will occur.",
+                          "ticker": "UBS"
+                        }
                       ],
-                      "published_utc": "2021-04-26T02:33:17Z",
+                      "keywords": [
+                        "Federal Reserve",
+                        "interest rates",
+                        "economic data"
+                      ],
+                      "published_utc": "2024-06-24T18:33:53Z",
                       "publisher": {
-                        "favicon_url": "https://s3.polygon.io/public/public/assets/news/favicons/benzinga.ico",
-                        "homepage_url": "https://www.benzinga.com/",
-                        "logo_url": "https://s3.polygon.io/public/public/assets/news/logos/benzinga.svg",
-                        "name": "Benzinga"
+                        "favicon_url": "https://s3.polygon.io/public/assets/news/favicons/investing.ico",
+                        "homepage_url": "https://www.investing.com/",
+                        "logo_url": "https://s3.polygon.io/public/assets/news/logos/investing.png",
+                        "name": "Investing.com"
                       },
                       "tickers": [
-                        "DOCU",
-                        "DDD",
-                        "NIU",
-                        "ARKF",
-                        "NVDA",
-                        "SKLZ",
-                        "PCAR",
-                        "MASS",
-                        "PSTI",
-                        "SPFR",
-                        "TREE",
-                        "PHR",
-                        "IRDM",
-                        "BEAM",
-                        "ARKW",
-                        "ARKK",
-                        "ARKG",
-                        "PSTG",
-                        "SQ",
-                        "IONS",
-                        "SYRS"
+                        "UBS"
                       ],
-                      "title": "Cathie Wood Adds More Coinbase, Skillz, Trims Square"
+                      "title": "Markets are underestimating Fed cuts: UBS By Investing.com - Investing.com UK"
                     }
                   ],
                   "status": "OK"
@@ -18586,6 +18569,32 @@
                           "image_url": {
                             "description": "The article's image URL.",
                             "type": "string"
+                          },
+                          "insights": {
+                            "description": "The insights related to the article.",
+                            "items": {
+                              "properties": {
+                                "sentiment": {
+                                  "description": "The sentiment of the insight.",
+                                  "type": "string"
+                                },
+                                "sentiment_reasoning": {
+                                  "description": "The reasoning behind the sentiment.",
+                                  "type": "string"
+                                },
+                                "ticker": {
+                                  "description": "The ticker symbol associated with the insight.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "ticker",
+                                "sentiment",
+                                "sentiment_reasoning"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
                           },
                           "keywords": {
                             "description": "The keywords associated with the article (which will vary depending on\nthe publishing source).",
@@ -18667,7 +18676,7 @@
                 }
               },
               "text/csv": {
-                "example": "id,publisher_name,publisher_homepage_url,publisher_logo_url,publisher_favicon_url,title,author,published_utc,article_url,tickers,amp_url,image_url,description,keywords\nnJsSJJdwViHZcw5367rZi7_qkXLfMzacXBfpv-vD9UA,Benzinga,https://www.benzinga.com/,https://s3.polygon.io/public/public/assets/news/logos/benzinga.svg,https://s3.polygon.io/public/public/assets/news/favicons/benzinga.ico,\"Cathie Wood Adds More Coinbase, Skillz, Trims Square\",Rachit  Vats,2021-04-26T02:33:17Z,https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square,\"DOCU,DDD,NIU,ARKF,NVDA,SKLZ,PCAR,MASS,PSTI,SPFR,TREE,PHR,IRDM,BEAM,ARKW,ARKK,ARKG,PSTG,SQ,IONS,SYRS\",https://amp.benzinga.com/amp/content/20784086,https://cdn2.benzinga.com/files/imagecache/og_image_social_share_1200x630/images/story/2012/andre-francois-mckenzie-auhr4gcqcce-unsplash.jpg?width=720,\"\u003cp\u003eCathie Wood-led Ark Investment Management on Friday snapped up another 221,167 shares of the cryptocurrency exchange \u003cstrong\u003eCoinbase Global Inc \u003c/strong\u003e(NASDAQ \u003ca class=\\\"ticker\\\" href=\\\"https://www.benzinga.com/stock/coin#NASDAQ\\\"\u003eCOIN\u003c/a\u003e) worth about $64.49 million on the stock\u0026rsquo;s Friday\u0026rsquo;s dip and also its fourth-straight loss.\u003c/p\u003e \u003cp\u003eThe investment firm\u0026rsquo;s \u003cstrong\u003eArk Innovation ETF\u003c/strong\u003e (NYSE \u003ca class=\\\" ticker\\\" href=\\\"https://www.benzinga.com/stock/arkk#NYSE\\\"\u003eARKK\u003c/a\u003e) bought the shares of the company that closed 0.63% lower at $291.60 on Friday, giving the cryptocurrency exchange a market cap of $58.09 billion. Coinbase\u0026rsquo;s market cap has dropped from $85.8 billion on its blockbuster listing earlier this month.\u003c/p\u003e \u003cp\u003eThe New York-based company also added another 3,873 shares of the mobile gaming company \u003cstrong\u003eSkillz Inc\u003c/strong\u003e (NYSE \u003ca class=\\\" ticker\\\" href=\\\"https://www.benzinga.com/stock/sklz#NYSE\\\"\u003eSKLZ\u003c/a\u003e), \u003ca href=\\\"http://www.benzinga.com/markets/cryptocurrency/21/04/20762794/cathie-woods-ark-loads-up-another-1-2-million-shares-in-skillz-also-adds-coinbase-draftkin\\\" \u003ejust a day after\u003c/a\u003e snapping 1.2 million shares of the stock.\u003c/p\u003e \u003cp\u003eARKK bought the shares of the company which closed ...\u003c/p\u003e\u003cp\u003e\u003ca href=https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square alt=Cathie Wood Adds More Coinbase, Skillz, Trims Square\u003eFull story available on Benzinga.com\u003c/a\u003e\u003c/p\u003e\",\"Sector ETFs,Penny Stocks,Cryptocurrency,Small Cap,Markets,Trading Ideas,ETFs\"\n",
+                "example": "id,publisher_name,publisher_homepage_url,publisher_logo_url,publisher_favicon_url,title,author,published_utc,article_url,ticker,amp_url,image_url,description,keywords,sentiment,sentiment_reasoning\n8ec638777ca03b553ae516761c2a22ba2fdd2f37befae3ab6fdab74e9e5193eb,Investing.com,https://www.investing.com/,https://s3.polygon.io/public/assets/news/logos/investing.png,https://s3.polygon.io/public/assets/news/favicons/investing.ico,Markets are underestimating Fed cuts: UBS By Investing.com - Investing.com UK,Sam Boughedda,1719254033000000000,https://uk.investing.com/news/stock-market-news/markets-are-underestimating-fed-cuts-ubs-3559968,UBS,https://m.uk.investing.com/news/stock-market-news/markets-are-underestimating-fed-cuts-ubs-3559968?ampMode=1,https://i-invdn-com.investing.com/news/LYNXNPEC4I0AL_L.jpg,\"UBS analysts warn that markets are underestimating the extent of future interest rate cuts by the Federal Reserve, as the weakening economy is likely to justify more cuts than currently anticipated.\",\"Federal Reserve,interest rates,economic data\",positive,\"UBS analysts are providing a bullish outlook on the extent of future Federal Reserve rate cuts, suggesting that markets are underestimating the number of cuts that will occur.\"\n",
                 "schema": {
                   "type": "string"
                 }
@@ -22864,11 +22873,11 @@
             }
           },
           {
-            "description": "Limit the number of results returned, default is 10 and max is 50000.",
+            "description": "Limit the number of results returned, default is 1000 and max is 50000.",
             "in": "query",
             "name": "limit",
             "schema": {
-              "default": 10,
+              "default": 1000,
               "example": 10,
               "maximum": 50000,
               "minimum": 1,
@@ -22993,7 +23002,7 @@
         },
         "x-polygon-paginate": {
           "limit": {
-            "default": 10,
+            "default": 1000,
             "example": 10,
             "max": 50000
           },
@@ -23091,11 +23100,11 @@
             }
           },
           {
-            "description": "Limit the number of results returned, default is 10 and max is 50000.",
+            "description": "Limit the number of results returned, default is 1000 and max is 50000.",
             "in": "query",
             "name": "limit",
             "schema": {
-              "default": 10,
+              "default": 1000,
               "example": 10,
               "maximum": 50000,
               "minimum": 1,
@@ -23242,7 +23251,7 @@
         },
         "x-polygon-paginate": {
           "limit": {
-            "default": 10,
+            "default": 1000,
             "example": 10,
             "max": 50000
           },
@@ -23333,11 +23342,11 @@
             }
           },
           {
-            "description": "Limit the number of results returned, default is 10 and max is 50000.",
+            "description": "Limit the number of results returned, default is 1000 and max is 50000.",
             "in": "query",
             "name": "limit",
             "schema": {
-              "default": 10,
+              "default": 1000,
               "example": 10,
               "maximum": 50000,
               "minimum": 1,
@@ -23545,7 +23554,7 @@
         },
         "x-polygon-paginate": {
           "limit": {
-            "default": 10,
+            "default": 1000,
             "example": 10,
             "max": 50000
           },
@@ -29071,11 +29080,11 @@
             }
           },
           {
-            "description": "Limit the number of results returned, default is 10 and max is 50000.",
+            "description": "Limit the number of results returned, default is 1000 and max is 50000.",
             "in": "query",
             "name": "limit",
             "schema": {
-              "default": 10,
+              "default": 1000,
               "example": 10,
               "maximum": 50000,
               "minimum": 1,
@@ -29221,7 +29230,7 @@
         },
         "x-polygon-paginate": {
           "limit": {
-            "default": 10,
+            "default": 1000,
             "example": 10,
             "max": 50000
           },
@@ -29319,11 +29328,11 @@
             }
           },
           {
-            "description": "Limit the number of results returned, default is 10 and max is 50000.",
+            "description": "Limit the number of results returned, default is 1000 and max is 50000.",
             "in": "query",
             "name": "limit",
             "schema": {
-              "default": 10,
+              "default": 1000,
               "example": 10,
               "maximum": 50000,
               "minimum": 1,
@@ -29475,7 +29484,7 @@
         },
         "x-polygon-paginate": {
           "limit": {
-            "default": 10,
+            "default": 1000,
             "example": 10,
             "max": 50000
           },
@@ -29566,11 +29575,11 @@
             }
           },
           {
-            "description": "Limit the number of results returned, default is 10 and max is 50000.",
+            "description": "Limit the number of results returned, default is 1000 and max is 50000.",
             "in": "query",
             "name": "limit",
             "schema": {
-              "default": 10,
+              "default": 1000,
               "example": 10,
               "maximum": 50000,
               "minimum": 1,
@@ -29766,7 +29775,7 @@
         },
         "x-polygon-paginate": {
           "limit": {
-            "default": 10,
+            "default": 1000,
             "example": 10,
             "max": 50000
           },

--- a/rest/models/tickers.go
+++ b/rest/models/tickers.go
@@ -336,17 +336,25 @@ type Branding struct {
 
 // TickerNews contains information on a ticker news article.
 type TickerNews struct {
-	AMPURL       string    `json:"amp_url,omitempty"`
-	ArticleURL   string    `json:"article_url,omitempty"`
-	Author       string    `json:"author,omitempty"`
-	Description  string    `json:"description,omitempty"`
-	ID           string    `json:"id,omitempty"`
-	ImageURL     string    `json:"image_url,omitempty"`
-	Keywords     []string  `json:"keywords,omitempty"`
-	PublishedUTC Time      `json:"published_utc,omitempty"`
-	Publisher    Publisher `json:"publisher,omitempty"`
-	Tickers      []string  `json:"tickers,omitempty"`
-	Title        string    `json:"title,omitempty"`
+	AMPURL       string     `json:"amp_url,omitempty"`
+	ArticleURL   string     `json:"article_url,omitempty"`
+	Author       string     `json:"author,omitempty"`
+	Description  string     `json:"description,omitempty"`
+	ID           string     `json:"id,omitempty"`
+	ImageURL     string     `json:"image_url,omitempty"`
+	Insights     []Insights `json:"insights"`
+	Keywords     []string   `json:"keywords,omitempty"`
+	PublishedUTC Time       `json:"published_utc,omitempty"`
+	Publisher    Publisher  `json:"publisher,omitempty"`
+	Tickers      []string   `json:"tickers,omitempty"`
+	Title        string     `json:"title,omitempty"`
+}
+
+// Insights contains sentiment, reasoning, and the ticker symbol associated with the insight.
+type Insights struct {
+	Ticker             string `json:"ticker"`
+	Sentiment          string `json:"sentiment"`
+	SentimentReasoning string `json:"sentiment_reasoning"`
 }
 
 // Publisher contains information on a new article publisher.

--- a/rest/reference_test.go
+++ b/rest/reference_test.go
@@ -131,68 +131,76 @@ func TestListTickerNews(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	news1 := `{
-	"id": "nJsSJJdwViHZcw5367rZi7_qkXLfMzacXBfpv-vD9UA",
-	"publisher": {
-		"name": "Benzinga",
-		"homepage_url": "https://www.benzinga.com/",
-		"logo_url": "https://s3.polygon.io/public/public/assets/news/logos/benzinga.svg",
-		"favicon_url": "https://s3.polygon.io/public/public/assets/news/favicons/benzinga.ico"
-	},
-	"title": "Cathie Wood Adds More Coinbase, Skillz, Trims Square",
-	"author": "Rachit Vats",
-	"published_utc": "2021-04-26T02:33:17.000Z",
-	"article_url": "https://www.benzinga.com/markets/cryptocurrency/21/04/20784086/cathie-wood-adds-more-coinbase-skillz-trims-square",
-	"tickers": [
-		"DOCU",
-		"DDD",
-		"NIU",
-		"ARKF",
-		"NVDA",
-		"SKLZ",
-		"PCAR",
-		"MASS",
-		"PSTI",
-		"SPFR",
-		"TREE",
-		"PHR",
-		"IRDM",
-		"BEAM",
-		"ARKW",
-		"ARKK",
-		"ARKG",
-		"PSTG",
-		"SQ",
-		"IONS",
-		"SYRS"
-	],
-	"amp_url": "https://amp.benzinga.com/amp/content/20784086",
-	"image_url": "https://cdn2.benzinga.com/files/imagecache/og_image_social_share_1200x630/images/story/2012/andre-francois-mckenzie-auhr4gcqcce-unsplash.jpg?width=720",
-	"description": "Cathie Wood-led Ark Investment Management on Friday snapped up another 221,167 shares...",
-	"keywords": [
-		"Sector ETFs",
-		"Penny Stocks",
-		"Cryptocurrency",
-		"Small Cap",
-		"Markets",
-		"Trading Ideas",
-		"ETFs"
-	]
+		"id": "1bb0692621da5ab737f4b97ccbef9478ed6820be86474abf8d3b413f8d7d2419",
+		"publisher": {
+			"name": "The Motley Fool",
+			"homepage_url": "https://www.fool.com/",
+			"logo_url": "https://s3.polygon.io/public/assets/news/logos/themotleyfool.svg",
+			"favicon_url": "https://s3.polygon.io/public/assets/news/favicons/themotleyfool.ico"
+		},
+		"title": "Should NVIDIA Investors Be Concerned About This Massive Risk? - The Motley Fool",
+		"author": "Travis Hoium",
+		"published_utc": "2024-07-17T16:08:34Z",
+		"article_url": "https://www.fool.com/investing/2024/07/17/should-nvidia-investors-be-concerned-about-this-ma/",
+		"tickers": [
+			"NVDA",
+			"GOOG",
+			"GOOGL",
+			"META",
+			"MSFT"
+		],
+		"image_url": "https://g.foolcdn.com/editorial/images/783626/ai-chip-black.jpg",
+		"description": "NVIDIA's revenue is heavily concentrated among a few customers, which poses a significant risk to its long-term profitability. The company's growth has been driven by a small number of companies ordering AI chips, and this customer concentration could lead to disappointment for investors.",
+		"keywords": [
+			"NVIDIA",
+			"customer concentration",
+			"risk",
+			"long-term profitability",
+			"AI chips"
+		],
+		"insights": [
+			{
+				"ticker": "NVDA",
+				"sentiment": "negative",
+				"sentiment_reasoning": "The article highlights that a few customers make up a huge amount of NVIDIA's revenue, which is a huge risk for the company's long-term profitability. This customer concentration could lead to disappointment for investors."
+			},
+			{
+				"ticker": "GOOG",
+				"sentiment": "neutral",
+				"sentiment_reasoning": "Suzanne Frey, an executive at Alphabet, is a member of The Motley Fool's board of directors, but the article does not mention Alphabet in the context of NVIDIA's customer concentration risk."
+			},
+			{
+				"ticker": "GOOGL",
+				"sentiment": "neutral",
+				"sentiment_reasoning": "Suzanne Frey, an executive at Alphabet, is a member of The Motley Fool's board of directors, but the article does not mention Alphabet in the context of NVIDIA's customer concentration risk."
+			},
+			{
+				"ticker": "META",
+				"sentiment": "neutral",
+				"sentiment_reasoning": "Randi Zuckerberg, a former director of market development and spokeswoman for Facebook (now Meta Platforms), is a member of The Motley Fool's board of directors, but the article does not mention Meta Platforms in the context of NVIDIA's customer concentration risk."
+			},
+			{
+				"ticker": "MSFT",
+				"sentiment": "neutral",
+				"sentiment_reasoning": "The article does not mention Microsoft in the context of NVIDIA's customer concentration risk."
+			}
+		]
 }`
 
 	expectedResponse := `{
 	"status": "OK",
 	"count": 1,
-	"next_url": "https://api.polygon.io/v2/reference/news?cursor=eyJsaW1pdCI6MSwic29ydCI6InB1Ymxpc2hlZF91dGMiLCJvcmRlciI6ImFzY2VuZGluZyIsInRpY2tlciI6e30sInB1Ymxpc2hlZF91dGMiOnsiZ3RlIjoiMjAyMS0wNC0yNiJ9LCJzZWFyY2hfYWZ0ZXIiOlsxNjE5NDA0Mzk3MDAwLG51bGxdfQ",
-	"request_id": "831afdb0b8078549fed053476984947a",
+	"next_url": "https://api.polygon.io/v2/reference/news?cursor=YXA9MjAyNC0wNy0xN1QxNiUzQTA4JTNBMzRaJmFzPTFiYjA2OTI2MjFkYTVhYjczN2Y0Yjk3Y2NiZWY5NDc4ZWQ2ODIwYmU4NjQ3NGFiZjhkM2I0MTNmOGQ3ZDI0MTkmbGltaXQ9MSZvcmRlcj1kZXNjZW5kaW5nJnRpY2tlcj1NU0ZU",
+	"request_id": "2eff2a5bc193b01555b0d4ec91c8fdbf",
 	"results": [
 ` + indent(true, news1, "\t\t") + `
 	]
 }`
 
-	registerResponder("https://api.polygon.io/v2/reference/news?limit=2&order=asc&published_utc.lt=1626912000000&sort=published_utc&ticker.lte=AAPL", expectedResponse)
-	registerResponder("https://api.polygon.io/v2/reference/news?cursor=eyJsaW1pdCI6MSwic29ydCI6InB1Ymxpc2hlZF91dGMiLCJvcmRlciI6ImFzY2VuZGluZyIsInRpY2tlciI6e30sInB1Ymxpc2hlZF91dGMiOnsiZ3RlIjoiMjAyMS0wNC0yNiJ9LCJzZWFyY2hfYWZ0ZXIiOlsxNjE5NDA0Mzk3MDAwLG51bGxdfQ", "{}")
+	registerResponder("https://api.polygon.io/v2/reference/news?limit=2&order=asc&published_utc.lt=1626912000000&sort=published_utc&ticker.lte=MSFT", expectedResponse)
+	registerResponder("https://api.polygon.io/v2/reference/news?cursor=YXA9MjAyNC0wNy0xN1QxNiUzQTA4JTNBMzRaJmFzPTFiYjA2OTI2MjFkYTVhYjczN2Y0Yjk3Y2NiZWY5NDc4ZWQ2ODIwYmU4NjQ3NGFiZjhkM2I0MTNmOGQ3ZDI0MTkmbGltaXQ9MSZvcmRlcj1kZXNjZW5kaW5nJnRpY2tlcj1NU0ZU", "{}")
 	iter := c.ListTickerNews(context.Background(), models.ListTickerNewsParams{}.
-		WithTicker(models.LTE, "AAPL").WithPublishedUTC(models.LT, models.Millis(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))).
+		WithTicker(models.LTE, "MSFT").WithPublishedUTC(models.LT, models.Millis(time.Date(2021, 7, 22, 0, 0, 0, 0, time.UTC))).
 		WithSort(models.PublishedUTC).WithOrder(models.Asc).WithLimit(2))
 
 	// iter creation


### PR DESCRIPTION
Fixes https://github.com/polygon-io/client-go/issues/432.

Added Ticker News Insights support which now provides the sentiment (negative, neutral, or positive) along with the reasoning behind it.
- Updated the spec
- Added Insights to the `TickerNews` struct
- Updated test case with new json response object

I tested the [ticker news example script](https://github.com/polygon-io/client-go/blob/master/rest/example/stocks/ticker-news/main.go) and it results the sentiment insights now.