### PR TITLE
[PLAT-742] Adds ReconnectCallback to ws go-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-76.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-77.4%25-brightgreen)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -30,6 +30,12 @@ type Config struct {
 	// If this flag is `true`, it's up to the caller to handle all message types including auth and subscription responses.
 	BypassRawDataRouting bool
 
+	// ReconnectCallback is a callback that is triggered on automatic reconnects by the websocket client.
+	// This can be useful for implementing additional logic around reconnect paths e.g. logging, metrics
+	// or managing the connection. The callback function takes as input an error type which will be non-nil
+	// if the reconnect attempt has failed and is being retried, and will be nil on reconnect success.
+	ReconnectCallback func(error)
+
 	// Log is an optional logger. Any logger implementation can be used as long as it
 	// implements the basic Logger interface. Omitting this will disable client logging.
 	Log Logger


### PR DESCRIPTION
Adds a `ReconnectCallback` to the websocket go-client, useful for client side management of reconnects which are otherwise not exposed to the user.

The new callback functionality can be consumed similarly to the way it is used in the unit tests or similarly to this:
```
	reconnectCallback := func(err error) {
		reconnectCounter++
		if err != nil {
			logger.Errorf("unable to reconnect, retrying %d: %v", reconnectCounter, err.Error())
		} else {
			logger.Info("reconnect successful")
		}
	}

	client, err := polygonws.New(polygonws.Config{ReconnectCallback: reconnectCallback,   ...})
```
