### PR TITLE
ci: Prevent CI workflows on bot commits and README updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'README.md'
   pull_request:
     branches:
       - master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
       - v*
     branches:
       - master
+    paths-ignore:
+      - 'README.md'
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -5,6 +5,8 @@ on:
       - v*
     branches:
       - master
+    paths-ignore:
+      - 'README.md'
   pull_request:
 permissions:
   contents: write
@@ -40,7 +42,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add README.md
-          git commit -m "chore: Updated coverage badge."
+          git commit -m "chore: Updated coverage badge. [skip ci]"
           git fetch origin && git rebase origin/master
       - name: push-changes
         if: steps.verify-changed-files.outputs.files_changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
       - v*
     branches:
       - master
+    paths-ignore:
+      - 'README.md'
   pull_request:
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Polygon Go Client
-![Coverage](https://img.shields.io/badge/Coverage-77.4%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-77.1%25-brightgreen)
 
 <!-- todo: add a codecov badge -->
 <!-- todo: figure out a way to show all build statuses -->


### PR DESCRIPTION
This commit addresses an issue where the automated commits made by the code coverage bot, specifically updates to README.md, trigger the lint and test GitHub Actions workflows to stop. This behaviour leads to race conditions and unnecessary CI runs on commits that don't affect the codebase. A good example here this PR https://github.com/polygon-io/client-go/pull/453 where the badge gets updated and stops the tests from completing. It is also blocking this PR https://github.com/polygon-io/client-go/pull/454. 

Changes implemented:

- Added `[skip ci]` to the commit message in the `code-coverage` workflow to prevent triggering CI workflows on bot-generated commits.
- Modified `lint.yaml`, `codeql.yml`, and `test.yaml` workflows to Included `paths-ignore` for `README.md`, so changes to this file alone won't trigger the workflows.

By combining these methods, we can stop that pesky CI workflow and only run when relevant code changes occur.