### PR TITLE
[WIP] Adds Futures support (alpha)

### DIFF
--- a/rest/futures.go
+++ b/rest/futures.go
@@ -1,11 +1,13 @@
+// futures.go
 package polygon
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/polygon-io/client-go/rest/client"
 	"github.com/polygon-io/client-go/rest/iter"
 	"github.com/polygon-io/client-go/rest/models"
-	"net/http"
 )
 
 const (

--- a/rest/futures.go
+++ b/rest/futures.go
@@ -1,0 +1,113 @@
+package polygon
+
+import (
+	"context"
+	"github.com/polygon-io/client-go/rest/client"
+	"github.com/polygon-io/client-go/rest/iter"
+	"github.com/polygon-io/client-go/rest/models"
+	"net/http"
+)
+
+const (
+	ListFuturesAggsPath             = "/futures/vX/aggs/{ticker}"
+	ListFuturesContractsPath        = "/futures/vX/contracts"
+	GetFuturesContractPath          = "/futures/vX/contracts/{ticker}"
+	ListFuturesMarketStatusesPath   = "/futures/vX/market-status"
+	ListFuturesProductsPath         = "/futures/vX/products"
+	GetFuturesProductPath           = "/futures/vX/products/{product_code}"
+	ListFuturesSchedulesPath        = "/futures/vX/schedules"
+	ListFuturesProductSchedulesPath = "/futures/vX/products/{product_code}/schedules"
+	ListFuturesTradesPath           = "/futures/vX/trades/{ticker}"
+	ListFuturesQuotesPath           = "/futures/vX/quotes/{ticker}"
+)
+
+// FuturesClient provides methods for interacting with the futures REST API.
+type FuturesClient struct {
+	client.Client
+}
+
+// ListFuturesAggs retrieves a list of aggregates for a futures contract.
+func (fc *FuturesClient) ListFuturesAggs(ctx context.Context, params *models.ListFuturesAggsParams, options ...models.RequestOption) *iter.Iter[models.FuturesAggregate] {
+	return iter.NewIter(ctx, ListFuturesAggsPath, params, func(uri string) (iter.ListResponse, []models.FuturesAggregate, error) {
+		res := &models.ListFuturesAggsResponse{}
+		err := fc.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}
+
+// ListFuturesContracts retrieves a list of futures contracts.
+func (fc *FuturesClient) ListFuturesContracts(ctx context.Context, params *models.ListFuturesContractsParams, options ...models.RequestOption) *iter.Iter[models.FuturesContract] {
+	return iter.NewIter(ctx, ListFuturesContractsPath, params, func(uri string) (iter.ListResponse, []models.FuturesContract, error) {
+		res := &models.ListFuturesContractsResponse{}
+		err := fc.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}
+
+// GetFuturesContract retrieves details for a specific futures contract.
+func (fc *FuturesClient) GetFuturesContract(ctx context.Context, params *models.GetFuturesContractParams, options ...models.RequestOption) (*models.GetFuturesContractResponse, error) {
+	res := &models.GetFuturesContractResponse{}
+	err := fc.Call(ctx, http.MethodGet, GetFuturesContractPath, params, res, options...)
+	return res, err
+}
+
+// ListFuturesMarketStatuses retrieves market statuses for futures products.
+func (fc *FuturesClient) ListFuturesMarketStatuses(ctx context.Context, params *models.ListFuturesMarketStatusesParams, options ...models.RequestOption) *iter.Iter[models.FuturesMarketStatus] {
+	return iter.NewIter(ctx, ListFuturesMarketStatusesPath, params, func(uri string) (iter.ListResponse, []models.FuturesMarketStatus, error) {
+		res := &models.ListFuturesMarketStatusesResponse{}
+		err := fc.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}
+
+// ListFuturesProducts retrieves a list of futures products.
+func (fc *FuturesClient) ListFuturesProducts(ctx context.Context, params *models.ListFuturesProductsParams, options ...models.RequestOption) *iter.Iter[models.FuturesProduct] {
+	return iter.NewIter(ctx, ListFuturesProductsPath, params, func(uri string) (iter.ListResponse, []models.FuturesProduct, error) {
+		res := &models.ListFuturesProductsResponse{}
+		err := fc.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}
+
+// GetFuturesProduct retrieves details for a specific futures product.
+func (fc *FuturesClient) GetFuturesProduct(ctx context.Context, params *models.GetFuturesProductParams, options ...models.RequestOption) (*models.GetFuturesProductResponse, error) {
+	res := &models.GetFuturesProductResponse{}
+	err := fc.Call(ctx, http.MethodGet, GetFuturesProductPath, params, res, options...)
+	return res, err
+}
+
+// ListFuturesSchedules retrieves trading schedules for futures.
+func (fc *FuturesClient) ListFuturesSchedules(ctx context.Context, params *models.ListFuturesSchedulesParams, options ...models.RequestOption) *iter.Iter[models.FuturesSchedule] {
+	return iter.NewIter(ctx, ListFuturesSchedulesPath, params, func(uri string) (iter.ListResponse, []models.FuturesSchedule, error) {
+		res := &models.ListFuturesSchedulesResponse{}
+		err := fc.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}
+
+// ListFuturesProductSchedules retrieves trading schedules for a specific futures product.
+func (fc *FuturesClient) ListFuturesProductSchedules(ctx context.Context, params *models.ListFuturesProductSchedulesParams, options ...models.RequestOption) *iter.Iter[models.FuturesSchedule] {
+	return iter.NewIter(ctx, ListFuturesProductSchedulesPath, params, func(uri string) (iter.ListResponse, []models.FuturesSchedule, error) {
+		res := &models.ListFuturesProductSchedulesResponse{}
+		err := fc.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}
+
+// ListFuturesTrades retrieves a list of trades for a futures contract.
+func (fc *FuturesClient) ListFuturesTrades(ctx context.Context, params *models.ListFuturesTradesParams, options ...models.RequestOption) *iter.Iter[models.FuturesTrade] {
+	return iter.NewIter(ctx, ListFuturesTradesPath, params, func(uri string) (iter.ListResponse, []models.FuturesTrade, error) {
+		res := &models.ListFuturesTradesResponse{}
+		err := fc.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}
+
+// ListFuturesQuotes retrieves a list of quotes for a futures contract.
+func (fc *FuturesClient) ListFuturesQuotes(ctx context.Context, params *models.ListFuturesQuotesParams, options ...models.RequestOption) *iter.Iter[models.FuturesQuote] {
+	return iter.NewIter(ctx, ListFuturesQuotesPath, params, func(uri string) (iter.ListResponse, []models.FuturesQuote, error) {
+		res := &models.ListFuturesQuotesResponse{}
+		err := fc.CallURL(ctx, http.MethodGet, uri, res, options...)
+		return res, res.Results, err
+	})
+}

--- a/rest/models/futures.go
+++ b/rest/models/futures.go
@@ -1,0 +1,248 @@
+package models
+
+import (
+	"time"
+)
+
+// ListFuturesAggsParams defines parameters for listing futures aggregates.
+type ListFuturesAggsParams struct {
+	Ticker         string `validate:"required" path:"ticker"`
+	Resolution     string `validate:"required" query:"resolution"`
+	WindowStart    *Nanos `query:"window_start"`
+	WindowStartGT  *Nanos `query:"window_start.gt"`
+	WindowStartGTE *Nanos `query:"window_start.gte"`
+	WindowStartLT  *Nanos `query:"window_start.lt"`
+	WindowStartLTE *Nanos `query:"window_start.lte"`
+	Order          *Order `query:"order"`
+	Limit          *int   `query:"limit"`
+	Sort           *Sort  `query:"sort"`
+}
+
+// ListFuturesContractsParams defines parameters for listing futures contracts.
+type ListFuturesContractsParams struct {
+	ProductCode    *string `query:"product_code"`
+	FirstTradeDate *Date   `query:"first_trade_date"`
+	LastTradeDate  *Date   `query:"last_trade_date"`
+	ExpirationDate *Date   `query:"expiration_date"`
+	Active         *string `query:"active"`
+	Type           *string `query:"type"`
+	Order          *Order  `query:"order"`
+	Limit          *int    `query:"limit"`
+	Sort           *Sort   `query:"sort"`
+}
+
+// GetFuturesContractParams defines parameters for retrieving a specific futures contract.
+type GetFuturesContractParams struct {
+	Ticker string `validate:"required" path:"ticker"`
+	AsOf   *Date  `query:"as_of"`
+}
+
+// ListFuturesMarketStatusesParams defines parameters for listing market statuses.
+type ListFuturesMarketStatusesParams struct {
+	ProductCode  *string `query:"product_code"`
+	ExchangeCode *string `query:"exchange_code"`
+	Order        *Order  `query:"order"`
+	Limit        *int    `query:"limit"`
+	Sort         *Sort   `query:"sort"`
+}
+
+// ListFuturesProductsParams defines parameters for listing futures products.
+type ListFuturesProductsParams struct {
+	Name         *string `query:"name"`
+	AssetClass   *string `query:"asset_class"`
+	ExchangeCode *string `query:"exchange_code"`
+	Sector       *string `query:"sector"`
+	SubSector    *string `query:"sub_sector"`
+	Type         *string `query:"type"`
+	Order        *Order  `query:"order"`
+	Limit        *int    `query:"limit"`
+	Sort         *Sort   `query:"sort"`
+}
+
+// GetFuturesProductParams defines parameters for retrieving a specific futures product.
+type GetFuturesProductParams struct {
+	ProductCode string `validate:"required" path:"product_code"`
+	AsOf        *Date  `query:"as_of"`
+}
+
+// ListFuturesSchedulesParams defines parameters for listing futures schedules.
+type ListFuturesSchedulesParams struct {
+	SessionStartDate     *Date   `query:"session_start_date"`
+	MarketIdentifierCode *string `query:"market_identifier_code"`
+	Order                *Order  `query:"order"`
+	Limit                *int    `query:"limit"`
+	Sort                 *Sort   `query:"sort"`
+}
+
+// ListFuturesProductSchedulesParams defines parameters for listing schedules for a specific product.
+type ListFuturesProductSchedulesParams struct {
+	ProductCode       string `validate:"required" path:"product_code"`
+	SessionEndDate    *Date  `query:"session_end_date"`
+	SessionEndDateGT  *Date  `query:"session_end_date.gt"`
+	SessionEndDateGTE *Date  `query:"session_end_date.gte"`
+	SessionEndDateLT  *Date  `query:"session_end_date.lt"`
+	SessionEndDateLTE *Date  `query:"session_end_date.lte"`
+	Order             *Order `query:"order"`
+	Limit             *int   `query:"limit"`
+}
+
+// ListFuturesTradesParams defines parameters for listing futures trades.
+type ListFuturesTradesParams struct {
+	Ticker       string `validate:"required" path:"ticker"`
+	Timestamp    *Nanos `query:"timestamp"`
+	TimestampGT  *Nanos `query:"timestamp.gt"`
+	TimestampGTE *Nanos `query:"timestamp.gte"`
+	TimestampLT  *Nanos `query:"timestamp.lt"`
+	TimestampLTE *Nanos `query:"timestamp.lte"`
+	Order        *Order `query:"order"`
+	Limit        *int   `query:"limit"`
+	Sort         *Sort  `query:"sort"`
+}
+
+// ListFuturesQuotesParams defines parameters for listing futures quotes.
+type ListFuturesQuotesParams struct {
+	Ticker       string `validate:"required" path:"ticker"`
+	Timestamp    *Nanos `query:"timestamp"`
+	TimestampGT  *Nanos `query:"timestamp.gt"`
+	TimestampGTE *Nanos `query:"timestamp.gte"`
+	TimestampLT  *Nanos `query:"timestamp.lt"`
+	TimestampLTE *Nanos `query:"timestamp.lte"`
+	Order        *Order `query:"order"`
+	Limit        *int   `query:"limit"`
+	Sort         *Sort  `query:"sort"`
+}
+
+// FuturesAggregate represents a single aggregate bar for futures.
+type FuturesAggregate struct {
+	Ticker      string  `json:"ticker"`
+	Open        float64 `json:"open"`
+	High        float64 `json:"high"`
+	Low         float64 `json:"low"`
+	Close       float64 `json:"close"`
+	Volume      int64   `json:"volume"`
+	WindowStart int64   `json:"window_start"`
+	WindowEnd   int64   `json:"window_end"`
+}
+
+// ListFuturesAggsResponse defines the response for listing futures aggregates.
+type ListFuturesAggsResponse struct {
+	BaseResponse
+	Results []FuturesAggregate `json:"results,omitempty"`
+}
+
+// FuturesContract represents a futures contract.
+type FuturesContract struct {
+	Ticker         string `json:"ticker"`
+	ProductCode    string `json:"product_code"`
+	ExpirationDate Date   `json:"expiration_date"`
+	FirstTradeDate Date   `json:"first_trade_date"`
+	LastTradeDate  Date   `json:"last_trade_date"`
+	Active         bool   `json:"active"`
+	Type           string `json:"type"`
+}
+
+// ListFuturesContractsResponse defines the response for listing futures contracts.
+type ListFuturesContractsResponse struct {
+	BaseResponse
+	Results []FuturesContract `json:"results,omitempty"`
+}
+
+// GetFuturesContractResponse defines the response for retrieving a specific futures contract.
+type GetFuturesContractResponse struct {
+	BaseResponse
+	Result FuturesContract `json:"result,omitempty"`
+}
+
+// FuturesMarketStatus represents the market status for a futures product.
+type FuturesMarketStatus struct {
+	ProductCode  string `json:"product_code"`
+	ExchangeCode string `json:"exchange_code"`
+	MarketStatus string `json:"market_status"`
+	Timestamp    int64  `json:"timestamp"`
+}
+
+// ListFuturesMarketStatusesResponse defines the response for listing market statuses.
+type ListFuturesMarketStatusesResponse struct {
+	BaseResponse
+	Results []FuturesMarketStatus `json:"results,omitempty"`
+}
+
+// FuturesProduct represents a futures product.
+type FuturesProduct struct {
+	ProductCode  string `json:"product_code"`
+	Name         string `json:"name"`
+	AssetClass   string `json:"asset_class"`
+	ExchangeCode string `json:"exchange_code"`
+	Sector       string `json:"sector"`
+	SubSector    string `json:"sub_sector"`
+	Type         string `json:"type"`
+}
+
+// ListFuturesProductsResponse defines the response for listing futures products.
+type ListFuturesProductsResponse struct {
+	BaseResponse
+	Results []FuturesProduct `json:"results,omitempty"`
+}
+
+// GetFuturesProductResponse defines the response for retrieving a specific futures product.
+type GetFuturesProductResponse struct {
+	BaseResponse
+	Result FuturesProduct `json:"result,omitempty"`
+}
+
+// FuturesSchedule represents a trading schedule for futures.
+type FuturesSchedule struct {
+	MarketIdentifierCode string          `json:"market_identifier_code"`
+	ProductCode          string          `json:"product_code"`
+	ProductName          string          `json:"product_name"`
+	SessionEndDate       Date            `json:"session_end_date"`
+	Schedule             []ScheduleEvent `json:"schedule"`
+}
+
+// ScheduleEvent represents a single event in a schedule.
+type ScheduleEvent struct {
+	Event     string `json:"event"`
+	Timestamp string `json:"timestamp"`
+}
+
+// ListFuturesSchedulesResponse defines the response for listing futures schedules.
+type ListFuturesSchedulesResponse struct {
+	BaseResponse
+	Results []FuturesSchedule `json:"results,omitempty"`
+}
+
+// ListFuturesProductSchedulesResponse defines the response for listing schedules for a specific product.
+type ListFuturesProductSchedulesResponse struct {
+	BaseResponse
+	Results []FuturesSchedule `json:"results,omitempty"`
+}
+
+// FuturesTrade represents a trade event for futures.
+type FuturesTrade struct {
+	Price     float64 `json:"price"`
+	Size      float64 `json:"size"`
+	Ticker    string  `json:"ticker"`
+	Timestamp int64   `json:"timestamp"`
+}
+
+// ListFuturesTradesResponse defines the response for listing futures trades.
+type ListFuturesTradesResponse struct {
+	BaseResponse
+	Results []FuturesTrade `json:"results,omitempty"`
+}
+
+// FuturesQuote represents a quote event for futures.
+type FuturesQuote struct {
+	AskPrice  float64 `json:"ask_price"`
+	AskSize   float64 `json:"ask_size"`
+	BidPrice  float64 `json:"bid_price"`
+	BidSize   float64 `json:"bid_size"`
+	Ticker    string  `json:"ticker"`
+	Timestamp int64   `json:"timestamp"`
+}
+
+// ListFuturesQuotesResponse defines the response for listing futures quotes.
+type ListFuturesQuotesResponse struct {
+	BaseResponse
+	Results []FuturesQuote `json:"results,omitempty"`
+}

--- a/rest/models/futures.go
+++ b/rest/models/futures.go
@@ -1,248 +1,355 @@
+// models/futures.go
 package models
 
-import (
-	"time"
-)
-
-// ListFuturesAggsParams defines parameters for listing futures aggregates.
+// ListFuturesAggsParams defines parameters for the ListFuturesAggs endpoint.
 type ListFuturesAggsParams struct {
-	Ticker         string `validate:"required" path:"ticker"`
-	Resolution     string `validate:"required" query:"resolution"`
-	WindowStart    *Nanos `query:"window_start"`
-	WindowStartGT  *Nanos `query:"window_start.gt"`
-	WindowStartGTE *Nanos `query:"window_start.gte"`
-	WindowStartLT  *Nanos `query:"window_start.lt"`
-	WindowStartLTE *Nanos `query:"window_start.lte"`
-	Order          *Order `query:"order"`
-	Limit          *int   `query:"limit"`
-	Sort           *Sort  `query:"sort"`
+	Ticker      string  `validate:"required" path:"ticker"`
+	Resolution  string  `query:"resolution"`
+	WindowStart *Nanos  `query:"window_start"`
+	WindowStartLT  *Nanos  `query:"window_start.lt"`
+	WindowStartLTE *Nanos  `query:"window_start.lte"`
+	WindowStartGT  *Nanos  `query:"window_start.gt"`
+	WindowStartGTE *Nanos  `query:"window_start.gte"`
+	Limit       *int    `query:"limit"`
+	Sort        *string `query:"sort"`
 }
 
-// ListFuturesContractsParams defines parameters for listing futures contracts.
-type ListFuturesContractsParams struct {
-	ProductCode    *string `query:"product_code"`
-	FirstTradeDate *Date   `query:"first_trade_date"`
-	LastTradeDate  *Date   `query:"last_trade_date"`
-	ExpirationDate *Date   `query:"expiration_date"`
-	Active         *string `query:"active"`
-	Type           *string `query:"type"`
-	Order          *Order  `query:"order"`
-	Limit          *int    `query:"limit"`
-	Sort           *Sort   `query:"sort"`
+func (p ListFuturesAggsParams) WithWindowStart(c Comparator, q Nanos) *ListFuturesAggsParams {
+	switch c {
+	case EQ:  p.WindowStart = &q
+	case LT:  p.WindowStartLT = &q
+	case LTE: p.WindowStartLTE = &q
+	case GT:  p.WindowStartGT = &q
+	case GTE: p.WindowStartGTE = &q
+	}
+	return &p
 }
 
-// GetFuturesContractParams defines parameters for retrieving a specific futures contract.
-type GetFuturesContractParams struct {
-	Ticker string `validate:"required" path:"ticker"`
-	AsOf   *Date  `query:"as_of"`
+func (p ListFuturesAggsParams) WithLimit(q int) *ListFuturesAggsParams {
+	p.Limit = &q
+	return &p
 }
 
-// ListFuturesMarketStatusesParams defines parameters for listing market statuses.
-type ListFuturesMarketStatusesParams struct {
-	ProductCode  *string `query:"product_code"`
-	ExchangeCode *string `query:"exchange_code"`
-	Order        *Order  `query:"order"`
-	Limit        *int    `query:"limit"`
-	Sort         *Sort   `query:"sort"`
+func (p ListFuturesAggsParams) WithSort(q string) *ListFuturesAggsParams {
+	p.Sort = &q
+	return &p
 }
 
-// ListFuturesProductsParams defines parameters for listing futures products.
-type ListFuturesProductsParams struct {
-	Name         *string `query:"name"`
-	AssetClass   *string `query:"asset_class"`
-	ExchangeCode *string `query:"exchange_code"`
-	Sector       *string `query:"sector"`
-	SubSector    *string `query:"sub_sector"`
-	Type         *string `query:"type"`
-	Order        *Order  `query:"order"`
-	Limit        *int    `query:"limit"`
-	Sort         *Sort   `query:"sort"`
-}
-
-// GetFuturesProductParams defines parameters for retrieving a specific futures product.
-type GetFuturesProductParams struct {
-	ProductCode string `validate:"required" path:"product_code"`
-	AsOf        *Date  `query:"as_of"`
-}
-
-// ListFuturesSchedulesParams defines parameters for listing futures schedules.
-type ListFuturesSchedulesParams struct {
-	SessionStartDate     *Date   `query:"session_start_date"`
-	MarketIdentifierCode *string `query:"market_identifier_code"`
-	Order                *Order  `query:"order"`
-	Limit                *int    `query:"limit"`
-	Sort                 *Sort   `query:"sort"`
-}
-
-// ListFuturesProductSchedulesParams defines parameters for listing schedules for a specific product.
-type ListFuturesProductSchedulesParams struct {
-	ProductCode       string `validate:"required" path:"product_code"`
-	SessionEndDate    *Date  `query:"session_end_date"`
-	SessionEndDateGT  *Date  `query:"session_end_date.gt"`
-	SessionEndDateGTE *Date  `query:"session_end_date.gte"`
-	SessionEndDateLT  *Date  `query:"session_end_date.lt"`
-	SessionEndDateLTE *Date  `query:"session_end_date.lte"`
-	Order             *Order `query:"order"`
-	Limit             *int   `query:"limit"`
-}
-
-// ListFuturesTradesParams defines parameters for listing futures trades.
-type ListFuturesTradesParams struct {
-	Ticker       string `validate:"required" path:"ticker"`
-	Timestamp    *Nanos `query:"timestamp"`
-	TimestampGT  *Nanos `query:"timestamp.gt"`
-	TimestampGTE *Nanos `query:"timestamp.gte"`
-	TimestampLT  *Nanos `query:"timestamp.lt"`
-	TimestampLTE *Nanos `query:"timestamp.lte"`
-	Order        *Order `query:"order"`
-	Limit        *int   `query:"limit"`
-	Sort         *Sort  `query:"sort"`
-}
-
-// ListFuturesQuotesParams defines parameters for listing futures quotes.
-type ListFuturesQuotesParams struct {
-	Ticker       string `validate:"required" path:"ticker"`
-	Timestamp    *Nanos `query:"timestamp"`
-	TimestampGT  *Nanos `query:"timestamp.gt"`
-	TimestampGTE *Nanos `query:"timestamp.gte"`
-	TimestampLT  *Nanos `query:"timestamp.lt"`
-	TimestampLTE *Nanos `query:"timestamp.lte"`
-	Order        *Order `query:"order"`
-	Limit        *int   `query:"limit"`
-	Sort         *Sort  `query:"sort"`
-}
-
-// FuturesAggregate represents a single aggregate bar for futures.
-type FuturesAggregate struct {
-	Ticker      string  `json:"ticker"`
-	Open        float64 `json:"open"`
-	High        float64 `json:"high"`
-	Low         float64 `json:"low"`
-	Close       float64 `json:"close"`
-	Volume      int64   `json:"volume"`
-	WindowStart int64   `json:"window_start"`
-	WindowEnd   int64   `json:"window_end"`
-}
-
-// ListFuturesAggsResponse defines the response for listing futures aggregates.
+// ListFuturesAggsResponse defines the response for the ListFuturesAggs endpoint.
 type ListFuturesAggsResponse struct {
 	BaseResponse
 	Results []FuturesAggregate `json:"results,omitempty"`
 }
 
-// FuturesContract represents a futures contract.
-type FuturesContract struct {
-	Ticker         string `json:"ticker"`
-	ProductCode    string `json:"product_code"`
-	ExpirationDate Date   `json:"expiration_date"`
-	FirstTradeDate Date   `json:"first_trade_date"`
-	LastTradeDate  Date   `json:"last_trade_date"`
-	Active         bool   `json:"active"`
-	Type           string `json:"type"`
+// FuturesAggregate represents an aggregate for a futures contract.
+type FuturesAggregate struct {
+	Close           float64 `json:"close,omitempty"`
+	DollarVolume    float64 `json:"dollar_volume,omitempty"`
+	High            float64 `json:"high,omitempty"`
+	Low             float64 `json:"low,omitempty"`
+	Open            float64 `json:"open,omitempty"`
+	SessionEndDate  string  `json:"session_end_date,omitempty"`
+	SettlementPrice float64 `json:"settlement_price,omitempty"`
+	Ticker          string  `json:"ticker,omitempty"`
+	Transactions    int64   `json:"transaction_count,omitempty"`
+	UnderlyingAsset string  `json:"underlying_asset,omitempty"`
+	Volume          int64   `json:"volume,omitempty"`
+	WindowStart     Nanos   `json:"window_start,omitempty"`
 }
 
-// ListFuturesContractsResponse defines the response for listing futures contracts.
+// ListFuturesContractsParams defines parameters for the ListFuturesContracts endpoint.
+type ListFuturesContractsParams struct {
+	ProductCode     *string `query:"product_code"`
+	FirstTradeDate  *Date   `query:"first_trade_date"`
+	LastTradeDate   *Date   `query:"last_trade_date"`
+	AsOf            *Date   `query:"as_of"`
+	Active          *string `query:"active"`
+	Type            *string `query:"type"`
+	Limit           *int    `query:"limit"`
+	Sort            *string `query:"sort"`
+}
+
+// ListFuturesContractsResponse defines the response for the ListFuturesContracts endpoint.
 type ListFuturesContractsResponse struct {
 	BaseResponse
 	Results []FuturesContract `json:"results,omitempty"`
 }
 
-// GetFuturesContractResponse defines the response for retrieving a specific futures contract.
+// FuturesContract represents a futures contract.
+type FuturesContract struct {
+	Active            bool    `json:"active,omitempty"`
+	AsOf              Date    `json:"as_of,omitempty"`
+	DaysToMaturity    int     `json:"days_to_maturity,omitempty"`
+	FirstTradeDate    Date    `json:"first_trade_date,omitempty"`
+	LastTradeDate     Date    `json:"last_trade_date,omitempty"`
+	MaxOrderQuantity  int     `json:"max_order_quantity,omitempty"`
+	MinOrderQuantity  int     `json:"min_order_quantity,omitempty"`
+	Name              string  `json:"name,omitempty"`
+	ProductCode       string  `json:"product_code,omitempty"`
+	SettlementDate    Date    `json:"settlement_date,omitempty"`
+	SettlementTickSize float64 `json:"settlement_tick_size,omitempty"`
+	SpreadTickSize    float64 `json:"spread_tick_size,omitempty"`
+	Ticker            string  `json:"ticker,omitempty"`
+	TradeTickSize     float64 `json:"trade_tick_size,omitempty"`
+	TradingVenue      string  `json:"trading_venue,omitempty"`
+	Type              string  `json:"type,omitempty"`
+}
+
+// GetFuturesContractParams defines parameters for the GetFuturesContract endpoint.
+type GetFuturesContractParams struct {
+	Ticker string `validate:"required" path:"ticker"`
+	AsOf   *Date  `query:"as_of"`
+}
+
+// GetFuturesContractResponse defines the response for the GetFuturesContract endpoint.
 type GetFuturesContractResponse struct {
 	BaseResponse
-	Result FuturesContract `json:"result,omitempty"`
+	Results FuturesContract `json:"results,omitempty"`
+}
+
+// ListFuturesMarketStatusesParams defines parameters for the ListFuturesMarketStatuses endpoint.
+type ListFuturesMarketStatusesParams struct {
+	ProductCodeAnyOf *string `query:"product_code.any_of"`
+	ProductCode      *string `query:"product_code"`
+	Limit            *int    `query:"limit"`
+	Sort             *string `query:"sort"`
+}
+
+// ListFuturesMarketStatusesResponse defines the response for the ListFuturesMarketStatuses endpoint.
+type ListFuturesMarketStatusesResponse struct {
+	BaseResponse
+	Results   []FuturesMarketStatus `json:"results,omitempty"`
+	Timestamp string                `json:"timestamp,omitempty"`
 }
 
 // FuturesMarketStatus represents the market status for a futures product.
 type FuturesMarketStatus struct {
-	ProductCode  string `json:"product_code"`
-	ExchangeCode string `json:"exchange_code"`
-	MarketStatus string `json:"market_status"`
-	Timestamp    int64  `json:"timestamp"`
+	MarketStatus string `json:"market_status,omitempty"`
+	ProductCode  string `json:"product_code,omitempty"`
+	TradingVenue string `json:"trading_venue,omitempty"`
 }
 
-// ListFuturesMarketStatusesResponse defines the response for listing market statuses.
-type ListFuturesMarketStatusesResponse struct {
-	BaseResponse
-	Results []FuturesMarketStatus `json:"results,omitempty"`
+// ListFuturesProductsParams defines parameters for the ListFuturesProducts endpoint.
+type ListFuturesProductsParams struct {
+	Name           *string `query:"name"`
+	AsOf           *Date   `query:"as_of"`
+	TradingVenue   *string `query:"trading_venue"`
+	Sector         *string `query:"sector"`
+	SubSector      *string `query:"sub_sector"`
+	AssetClass     *string `query:"asset_class"`
+	AssetSubClass  *string `query:"asset_sub_class"`
+	Type           *string `query:"type"`
+	Limit          *int    `query:"limit"`
+	NameSearch     *string `query:"name.search"`
+	Sort           *string `query:"sort"`
 }
 
-// FuturesProduct represents a futures product.
-type FuturesProduct struct {
-	ProductCode  string `json:"product_code"`
-	Name         string `json:"name"`
-	AssetClass   string `json:"asset_class"`
-	ExchangeCode string `json:"exchange_code"`
-	Sector       string `json:"sector"`
-	SubSector    string `json:"sub_sector"`
-	Type         string `json:"type"`
-}
-
-// ListFuturesProductsResponse defines the response for listing futures products.
+// ListFuturesProductsResponse defines the response for the ListFuturesProducts endpoint.
 type ListFuturesProductsResponse struct {
 	BaseResponse
 	Results []FuturesProduct `json:"results,omitempty"`
 }
 
-// GetFuturesProductResponse defines the response for retrieving a specific futures product.
+// FuturesProduct represents a futures product.
+type FuturesProduct struct {
+	AsOf                 Date    `json:"as_of,omitempty"`
+	AssetClass           string  `json:"asset_class,omitempty"`
+	AssetSubClass        string  `json:"asset_sub_class,omitempty"`
+	ClearingChannel      string  `json:"clearing_channel,omitempty"`
+	LastUpdated          string  `json:"last_updated,omitempty"`
+	Name                 string  `json:"name,omitempty"`
+	PriceQuotation       string  `json:"price_quotation,omitempty"`
+	ProductCode          string  `json:"product_code,omitempty"`
+	Sector               string  `json:"sector,omitempty"`
+	SettlementCurrencyCode string `json:"settlement_currency_code,omitempty"`
+	SettlementMethod     string  `json:"settlement_method,omitempty"`
+	SettlementType       string  `json:"settlement_type,omitempty"`
+	SubSector            string  `json:"sub_sector,omitempty"`
+	TradeCurrencyCode    string `json:"trade_currency_code,omitempty"`
+	TradingVenue         string `json:"trading_venue,omitempty"`
+	Type                 string  `json:"type,omitempty"`
+	UnitOfMeasure        string `json:"unit_of_measure,omitempty"`
+	UnitOfMeasureQuantity float64 `json:"unit_of_measure_quantity,omitempty"`
+}
+
+// GetFuturesProductParams defines parameters for the GetFuturesProduct endpoint.
+type GetFuturesProductParams struct {
+	ProductCode string `validate:"required" path:"product_code"`
+	Type        *string `query:"type"`
+	AsOf        *Date   `query:"as_of"`
+}
+
+// GetFuturesProductResponse defines the response for the GetFuturesProduct endpoint.
 type GetFuturesProductResponse struct {
 	BaseResponse
-	Result FuturesProduct `json:"result,omitempty"`
+	Results FuturesProduct `json:"results,omitempty"`
 }
 
-// FuturesSchedule represents a trading schedule for futures.
-type FuturesSchedule struct {
-	MarketIdentifierCode string          `json:"market_identifier_code"`
-	ProductCode          string          `json:"product_code"`
-	ProductName          string          `json:"product_name"`
-	SessionEndDate       Date            `json:"session_end_date"`
-	Schedule             []ScheduleEvent `json:"schedule"`
+// ListFuturesProductSchedulesParams defines parameters for the ListFuturesProductSchedules endpoint.
+type ListFuturesProductSchedulesParams struct {
+	ProductCode      string  `validate:"required" path:"product_code"`
+	SessionEndDate   *Date   `query:"session_end_date"`
+	SessionEndDateLT  *Date  `query:"session_end_date.lt"`
+	SessionEndDateLTE *Date  `query:"session_end_date.lte"`
+	SessionEndDateGT  *Date  `query:"session_end_date.gt"`
+	SessionEndDateGTE *Date  `query:"session_end_date.gte"`
+	Limit            *int    `query:"limit"`
+	Sort             *string `query:"sort"`
 }
 
-// ScheduleEvent represents a single event in a schedule.
-type ScheduleEvent struct {
-	Event     string `json:"event"`
-	Timestamp string `json:"timestamp"`
+func (p ListFuturesProductSchedulesParams) WithSessionEndDate(c Comparator, q Date) *ListFuturesProductSchedulesParams {
+	switch c {
+	case EQ:  p.SessionEndDate = &q
+	case LT:  p.SessionEndDateLT = &q
+	case LTE: p.SessionEndDateLTE = &q
+	case GT:  p.SessionEndDateGT = &q
+	case GTE: p.SessionEndDateGTE = &q
+	}
+	return &p
 }
 
-// ListFuturesSchedulesResponse defines the response for listing futures schedules.
-type ListFuturesSchedulesResponse struct {
-	BaseResponse
-	Results []FuturesSchedule `json:"results,omitempty"`
-}
-
-// ListFuturesProductSchedulesResponse defines the response for listing schedules for a specific product.
+// ListFuturesProductSchedulesResponse defines the response for the ListFuturesProductSchedules endpoint.
 type ListFuturesProductSchedulesResponse struct {
 	BaseResponse
 	Results []FuturesSchedule `json:"results,omitempty"`
 }
 
-// FuturesTrade represents a trade event for futures.
-type FuturesTrade struct {
-	Price     float64 `json:"price"`
-	Size      float64 `json:"size"`
-	Ticker    string  `json:"ticker"`
-	Timestamp int64   `json:"timestamp"`
+// FuturesSchedule represents a trading schedule for a futures product.
+type FuturesSchedule struct {
+	ProductCode   string        `json:"product_code,omitempty"`
+	ProductName   string        `json:"product_name,omitempty"`
+	Schedule      []ScheduleEvent `json:"schedule,omitempty"`
+	SessionEndDate Date          `json:"session_end_date,omitempty"`
+	TradingVenue  string        `json:"trading_venue,omitempty"`
 }
 
-// ListFuturesTradesResponse defines the response for listing futures trades.
+type ScheduleEvent struct {
+	Event     string `json:"event,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+// ListFuturesQuotesParams defines parameters for the ListFuturesQuotes endpoint.
+type ListFuturesQuotesParams struct {
+	Ticker           string  `validate:"required" path:"ticker"`
+	Timestamp        *Nanos  `query:"timestamp"`
+	TimestampLT      *Nanos  `query:"timestamp.lt"`
+	TimestampLTE     *Nanos  `query:"timestamp.lte"`
+	TimestampGT      *Nanos  `query:"timestamp.gt"`
+	TimestampGTE     *Nanos  `query:"timestamp.gte"`
+	SessionEndDate   *string `query:"session_end_date"`
+	SessionEndDateLT  *string `query:"session_end_date.lt"`
+	SessionEndDateLTE *string `query:"session_end_date.lte"`
+	SessionEndDateGT  *string `query:"session_end_date.gt"`
+	SessionEndDateGTE *string `query:"session_end_date.gte"`
+	Limit            *int    `query:"limit"`
+	Sort             *string `query:"sort"`
+}
+
+func (p ListFuturesQuotesParams) WithTimestamp(c Comparator, q Nanos) *ListFuturesQuotesParams {
+	switch c {
+	case EQ:  p.Timestamp = &q
+	case LT:  p.TimestampLT = &q
+	case LTE: p.TimestampLTE = &q
+	case GT:  p.TimestampGT = &q
+	case GTE: p.TimestampGTE = &q
+	}
+	return &p
+}
+
+func (p ListFuturesQuotesParams) WithSessionEndDate(c Comparator, q string) *ListFuturesQuotesParams {
+	switch c {
+	case EQ:  p.SessionEndDate = &q
+	case LT:  p.SessionEndDateLT = &q
+	case LTE: p.SessionEndDateLTE = &q
+	case GT:  p.SessionEndDateGT = &q
+	case GTE: p.SessionEndDateGTE = &q
+	}
+	return &p
+}
+
+// ListFuturesQuotesResponse defines the response for the ListFuturesQuotes endpoint.
+type ListFuturesQuotesResponse struct {
+	BaseResponse
+	Results []FuturesQuote `json:"results,omitempty"`
+}
+
+// FuturesQuote represents a quote for a futures contract.
+type FuturesQuote struct {
+	AskPrice     float64 `json:"ask_price,omitempty"`
+	AskSize      float64 `json:"ask_size,omitempty"`
+	AskTimestamp Nanos   `json:"ask_timestamp,omitempty"`
+	BidPrice     float64 `json:"bid_price,omitempty"`
+	BidSize      float64 `json:"bid_size,omitempty"`
+	BidTimestamp Nanos   `json:"bid_timestamp,omitempty"`
+	SessionEndDate string `json:"session_end_date,omitempty"`
+	Ticker       string `json:"ticker,omitempty"`
+	Timestamp    Nanos   `json:"timestamp,omitempty"`
+}
+
+// ListFuturesSchedulesParams defines parameters for the ListFuturesSchedules endpoint.
+type ListFuturesSchedulesParams struct {
+	SessionEndDate *Date   `query:"session_end_date"`
+	TradingVenue   *string `query:"trading_venue"`
+	Limit          *int    `query:"limit"`
+	Sort           *string `query:"sort"`
+}
+
+// ListFuturesSchedulesResponse defines the response for the ListFuturesSchedules endpoint.
+type ListFuturesSchedulesResponse struct {
+	BaseResponse
+	Results []FuturesSchedule `json:"results,omitempty"`
+}
+
+// ListFuturesTradesParams defines parameters for the ListFuturesTrades endpoint.
+type ListFuturesTradesParams struct {
+	Ticker           string  `validate:"required" path:"ticker"`
+	Timestamp        *Nanos  `query:"timestamp"`
+	TimestampLT      *Nanos  `query:"timestamp.lt"`
+	TimestampLTE     *Nanos  `query:"timestamp.lte"`
+	TimestampGT      *Nanos  `query:"timestamp.gt"`
+	TimestampGTE     *Nanos  `query:"timestamp.gte"`
+	SessionEndDate   *string `query:"session_end_date"`
+	SessionEndDateLT  *string `query:"session_end_date.lt"`
+	SessionEndDateLTE *string `query:"session_end_date.lte"`
+	SessionEndDateGT  *string `query:"session_end_date.gt"`
+	SessionEndDateGTE *string `query:"session_end_date.gte"`
+	Limit            *int    `query:"limit"`
+	Sort             *string `query:"sort"`
+}
+
+func (p ListFuturesTradesParams) WithTimestamp(c Comparator, q Nanos) *ListFuturesTradesParams {
+	switch c {
+	case EQ:  p.Timestamp = &q
+	case LT:  p.TimestampLT = &q
+	case LTE: p.TimestampLTE = &q
+	case GT:  p.TimestampGT = &q
+	case GTE: p.TimestampGTE = &q
+	}
+	return &p
+}
+
+func (p ListFuturesTradesParams) WithSessionEndDate(c Comparator, q string) *ListFuturesTradesParams {
+	switch c {
+	case EQ:  p.SessionEndDate = &q
+	case LT:  p.SessionEndDateLT = &q
+	case LTE: p.SessionEndDateLTE = &q
+	case GT:  p.SessionEndDateGT = &q
+	case GTE: p.SessionEndDateGTE = &q
+	}
+	return &p
+}
+
+// ListFuturesTradesResponse defines the response for the ListFuturesTrades endpoint.
 type ListFuturesTradesResponse struct {
 	BaseResponse
 	Results []FuturesTrade `json:"results,omitempty"`
 }
 
-// FuturesQuote represents a quote event for futures.
-type FuturesQuote struct {
-	AskPrice  float64 `json:"ask_price"`
-	AskSize   float64 `json:"ask_size"`
-	BidPrice  float64 `json:"bid_price"`
-	BidSize   float64 `json:"bid_size"`
-	Ticker    string  `json:"ticker"`
-	Timestamp int64   `json:"timestamp"`
-}
-
-// ListFuturesQuotesResponse defines the response for listing futures quotes.
-type ListFuturesQuotesResponse struct {
-	BaseResponse
-	Results []FuturesQuote `json:"results,omitempty"`
+// FuturesTrade represents a trade for a futures contract.
+type FuturesTrade struct {
+	Price         float64 `json:"price,omitempty"`
+	SessionEndDate string `json:"session_end_date,omitempty"`
+	Size          float64 `json:"size,omitempty"`
+	Ticker        string `json:"ticker,omitempty"`
+	Timestamp     Nanos   `json:"timestamp,omitempty"`
 }

--- a/rest/models/futures.go
+++ b/rest/models/futures.go
@@ -3,24 +3,29 @@ package models
 
 // ListFuturesAggsParams defines parameters for the ListFuturesAggs endpoint.
 type ListFuturesAggsParams struct {
-	Ticker      string  `validate:"required" path:"ticker"`
-	Resolution  string  `query:"resolution"`
-	WindowStart *Nanos  `query:"window_start"`
+	Ticker         string  `validate:"required" path:"ticker"`
+	Resolution     string  `query:"resolution"`
+	WindowStart    *Nanos  `query:"window_start"`
 	WindowStartLT  *Nanos  `query:"window_start.lt"`
 	WindowStartLTE *Nanos  `query:"window_start.lte"`
 	WindowStartGT  *Nanos  `query:"window_start.gt"`
 	WindowStartGTE *Nanos  `query:"window_start.gte"`
-	Limit       *int    `query:"limit"`
-	Sort        *string `query:"sort"`
+	Limit          *int    `query:"limit"`
+	Sort           *string `query:"sort"`
 }
 
 func (p ListFuturesAggsParams) WithWindowStart(c Comparator, q Nanos) *ListFuturesAggsParams {
 	switch c {
-	case EQ:  p.WindowStart = &q
-	case LT:  p.WindowStartLT = &q
-	case LTE: p.WindowStartLTE = &q
-	case GT:  p.WindowStartGT = &q
-	case GTE: p.WindowStartGTE = &q
+	case EQ:
+		p.WindowStart = &q
+	case LT:
+		p.WindowStartLT = &q
+	case LTE:
+		p.WindowStartLTE = &q
+	case GT:
+		p.WindowStartGT = &q
+	case GTE:
+		p.WindowStartGTE = &q
 	}
 	return &p
 }
@@ -59,14 +64,14 @@ type FuturesAggregate struct {
 
 // ListFuturesContractsParams defines parameters for the ListFuturesContracts endpoint.
 type ListFuturesContractsParams struct {
-	ProductCode     *string `query:"product_code"`
-	FirstTradeDate  *Date   `query:"first_trade_date"`
-	LastTradeDate   *Date   `query:"last_trade_date"`
-	AsOf            *Date   `query:"as_of"`
-	Active          *string `query:"active"`
-	Type            *string `query:"type"`
-	Limit           *int    `query:"limit"`
-	Sort            *string `query:"sort"`
+	ProductCode    *string `query:"product_code"`
+	FirstTradeDate *Date   `query:"first_trade_date"`
+	LastTradeDate  *Date   `query:"last_trade_date"`
+	AsOf           *Date   `query:"as_of"`
+	Active         *string `query:"active"`
+	Type           *string `query:"type"`
+	Limit          *int    `query:"limit"`
+	Sort           *string `query:"sort"`
 }
 
 // ListFuturesContractsResponse defines the response for the ListFuturesContracts endpoint.
@@ -77,22 +82,22 @@ type ListFuturesContractsResponse struct {
 
 // FuturesContract represents a futures contract.
 type FuturesContract struct {
-	Active            bool    `json:"active,omitempty"`
-	AsOf              Date    `json:"as_of,omitempty"`
-	DaysToMaturity    int     `json:"days_to_maturity,omitempty"`
-	FirstTradeDate    Date    `json:"first_trade_date,omitempty"`
-	LastTradeDate     Date    `json:"last_trade_date,omitempty"`
-	MaxOrderQuantity  int     `json:"max_order_quantity,omitempty"`
-	MinOrderQuantity  int     `json:"min_order_quantity,omitempty"`
-	Name              string  `json:"name,omitempty"`
-	ProductCode       string  `json:"product_code,omitempty"`
-	SettlementDate    Date    `json:"settlement_date,omitempty"`
+	Active             bool    `json:"active,omitempty"`
+	AsOf               Date    `json:"as_of,omitempty"`
+	DaysToMaturity     int     `json:"days_to_maturity,omitempty"`
+	FirstTradeDate     Date    `json:"first_trade_date,omitempty"`
+	LastTradeDate      Date    `json:"last_trade_date,omitempty"`
+	MaxOrderQuantity   int     `json:"max_order_quantity,omitempty"`
+	MinOrderQuantity   int     `json:"min_order_quantity,omitempty"`
+	Name               string  `json:"name,omitempty"`
+	ProductCode        string  `json:"product_code,omitempty"`
+	SettlementDate     Date    `json:"settlement_date,omitempty"`
 	SettlementTickSize float64 `json:"settlement_tick_size,omitempty"`
-	SpreadTickSize    float64 `json:"spread_tick_size,omitempty"`
-	Ticker            string  `json:"ticker,omitempty"`
-	TradeTickSize     float64 `json:"trade_tick_size,omitempty"`
-	TradingVenue      string  `json:"trading_venue,omitempty"`
-	Type              string  `json:"type,omitempty"`
+	SpreadTickSize     float64 `json:"spread_tick_size,omitempty"`
+	Ticker             string  `json:"ticker,omitempty"`
+	TradeTickSize      float64 `json:"trade_tick_size,omitempty"`
+	TradingVenue       string  `json:"trading_venue,omitempty"`
+	Type               string  `json:"type,omitempty"`
 }
 
 // GetFuturesContractParams defines parameters for the GetFuturesContract endpoint.
@@ -131,17 +136,17 @@ type FuturesMarketStatus struct {
 
 // ListFuturesProductsParams defines parameters for the ListFuturesProducts endpoint.
 type ListFuturesProductsParams struct {
-	Name           *string `query:"name"`
-	AsOf           *Date   `query:"as_of"`
-	TradingVenue   *string `query:"trading_venue"`
-	Sector         *string `query:"sector"`
-	SubSector      *string `query:"sub_sector"`
-	AssetClass     *string `query:"asset_class"`
-	AssetSubClass  *string `query:"asset_sub_class"`
-	Type           *string `query:"type"`
-	Limit          *int    `query:"limit"`
-	NameSearch     *string `query:"name.search"`
-	Sort           *string `query:"sort"`
+	Name          *string `query:"name"`
+	AsOf          *Date   `query:"as_of"`
+	TradingVenue  *string `query:"trading_venue"`
+	Sector        *string `query:"sector"`
+	SubSector     *string `query:"sub_sector"`
+	AssetClass    *string `query:"asset_class"`
+	AssetSubClass *string `query:"asset_sub_class"`
+	Type          *string `query:"type"`
+	Limit         *int    `query:"limit"`
+	NameSearch    *string `query:"name.search"`
+	Sort          *string `query:"sort"`
 }
 
 // ListFuturesProductsResponse defines the response for the ListFuturesProducts endpoint.
@@ -152,29 +157,29 @@ type ListFuturesProductsResponse struct {
 
 // FuturesProduct represents a futures product.
 type FuturesProduct struct {
-	AsOf                 Date    `json:"as_of,omitempty"`
-	AssetClass           string  `json:"asset_class,omitempty"`
-	AssetSubClass        string  `json:"asset_sub_class,omitempty"`
-	ClearingChannel      string  `json:"clearing_channel,omitempty"`
-	LastUpdated          string  `json:"last_updated,omitempty"`
-	Name                 string  `json:"name,omitempty"`
-	PriceQuotation       string  `json:"price_quotation,omitempty"`
-	ProductCode          string  `json:"product_code,omitempty"`
-	Sector               string  `json:"sector,omitempty"`
-	SettlementCurrencyCode string `json:"settlement_currency_code,omitempty"`
-	SettlementMethod     string  `json:"settlement_method,omitempty"`
-	SettlementType       string  `json:"settlement_type,omitempty"`
-	SubSector            string  `json:"sub_sector,omitempty"`
-	TradeCurrencyCode    string `json:"trade_currency_code,omitempty"`
-	TradingVenue         string `json:"trading_venue,omitempty"`
-	Type                 string  `json:"type,omitempty"`
-	UnitOfMeasure        string `json:"unit_of_measure,omitempty"`
-	UnitOfMeasureQuantity float64 `json:"unit_of_measure_quantity,omitempty"`
+	AsOf                   Date    `json:"as_of,omitempty"`
+	AssetClass             string  `json:"asset_class,omitempty"`
+	AssetSubClass          string  `json:"asset_sub_class,omitempty"`
+	ClearingChannel        string  `json:"clearing_channel,omitempty"`
+	LastUpdated            string  `json:"last_updated,omitempty"`
+	Name                   string  `json:"name,omitempty"`
+	PriceQuotation         string  `json:"price_quotation,omitempty"`
+	ProductCode            string  `json:"product_code,omitempty"`
+	Sector                 string  `json:"sector,omitempty"`
+	SettlementCurrencyCode string  `json:"settlement_currency_code,omitempty"`
+	SettlementMethod       string  `json:"settlement_method,omitempty"`
+	SettlementType         string  `json:"settlement_type,omitempty"`
+	SubSector              string  `json:"sub_sector,omitempty"`
+	TradeCurrencyCode      string  `json:"trade_currency_code,omitempty"`
+	TradingVenue           string  `json:"trading_venue,omitempty"`
+	Type                   string  `json:"type,omitempty"`
+	UnitOfMeasure          string  `json:"unit_of_measure,omitempty"`
+	UnitOfMeasureQuantity  float64 `json:"unit_of_measure_quantity,omitempty"`
 }
 
 // GetFuturesProductParams defines parameters for the GetFuturesProduct endpoint.
 type GetFuturesProductParams struct {
-	ProductCode string `validate:"required" path:"product_code"`
+	ProductCode string  `validate:"required" path:"product_code"`
 	Type        *string `query:"type"`
 	AsOf        *Date   `query:"as_of"`
 }
@@ -187,23 +192,28 @@ type GetFuturesProductResponse struct {
 
 // ListFuturesProductSchedulesParams defines parameters for the ListFuturesProductSchedules endpoint.
 type ListFuturesProductSchedulesParams struct {
-	ProductCode      string  `validate:"required" path:"product_code"`
-	SessionEndDate   *Date   `query:"session_end_date"`
-	SessionEndDateLT  *Date  `query:"session_end_date.lt"`
-	SessionEndDateLTE *Date  `query:"session_end_date.lte"`
-	SessionEndDateGT  *Date  `query:"session_end_date.gt"`
-	SessionEndDateGTE *Date  `query:"session_end_date.gte"`
-	Limit            *int    `query:"limit"`
-	Sort             *string `query:"sort"`
+	ProductCode       string  `validate:"required" path:"product_code"`
+	SessionEndDate    *Date   `query:"session_end_date"`
+	SessionEndDateLT  *Date   `query:"session_end_date.lt"`
+	SessionEndDateLTE *Date   `query:"session_end_date.lte"`
+	SessionEndDateGT  *Date   `query:"session_end_date.gt"`
+	SessionEndDateGTE *Date   `query:"session_end_date.gte"`
+	Limit             *int    `query:"limit"`
+	Sort              *string `query:"sort"`
 }
 
 func (p ListFuturesProductSchedulesParams) WithSessionEndDate(c Comparator, q Date) *ListFuturesProductSchedulesParams {
 	switch c {
-	case EQ:  p.SessionEndDate = &q
-	case LT:  p.SessionEndDateLT = &q
-	case LTE: p.SessionEndDateLTE = &q
-	case GT:  p.SessionEndDateGT = &q
-	case GTE: p.SessionEndDateGTE = &q
+	case EQ:
+		p.SessionEndDate = &q
+	case LT:
+		p.SessionEndDateLT = &q
+	case LTE:
+		p.SessionEndDateLTE = &q
+	case GT:
+		p.SessionEndDateGT = &q
+	case GTE:
+		p.SessionEndDateGTE = &q
 	}
 	return &p
 }
@@ -216,11 +226,11 @@ type ListFuturesProductSchedulesResponse struct {
 
 // FuturesSchedule represents a trading schedule for a futures product.
 type FuturesSchedule struct {
-	ProductCode   string        `json:"product_code,omitempty"`
-	ProductName   string        `json:"product_name,omitempty"`
-	Schedule      []ScheduleEvent `json:"schedule,omitempty"`
-	SessionEndDate Date          `json:"session_end_date,omitempty"`
-	TradingVenue  string        `json:"trading_venue,omitempty"`
+	ProductCode    string          `json:"product_code,omitempty"`
+	ProductName    string          `json:"product_name,omitempty"`
+	Schedule       []ScheduleEvent `json:"schedule,omitempty"`
+	SessionEndDate Date            `json:"session_end_date,omitempty"`
+	TradingVenue   string          `json:"trading_venue,omitempty"`
 }
 
 type ScheduleEvent struct {
@@ -230,39 +240,49 @@ type ScheduleEvent struct {
 
 // ListFuturesQuotesParams defines parameters for the ListFuturesQuotes endpoint.
 type ListFuturesQuotesParams struct {
-	Ticker           string  `validate:"required" path:"ticker"`
-	Timestamp        *Nanos  `query:"timestamp"`
-	TimestampLT      *Nanos  `query:"timestamp.lt"`
-	TimestampLTE     *Nanos  `query:"timestamp.lte"`
-	TimestampGT      *Nanos  `query:"timestamp.gt"`
-	TimestampGTE     *Nanos  `query:"timestamp.gte"`
-	SessionEndDate   *string `query:"session_end_date"`
+	Ticker            string  `validate:"required" path:"ticker"`
+	Timestamp         *Nanos  `query:"timestamp"`
+	TimestampLT       *Nanos  `query:"timestamp.lt"`
+	TimestampLTE      *Nanos  `query:"timestamp.lte"`
+	TimestampGT       *Nanos  `query:"timestamp.gt"`
+	TimestampGTE      *Nanos  `query:"timestamp.gte"`
+	SessionEndDate    *string `query:"session_end_date"`
 	SessionEndDateLT  *string `query:"session_end_date.lt"`
 	SessionEndDateLTE *string `query:"session_end_date.lte"`
 	SessionEndDateGT  *string `query:"session_end_date.gt"`
 	SessionEndDateGTE *string `query:"session_end_date.gte"`
-	Limit            *int    `query:"limit"`
-	Sort             *string `query:"sort"`
+	Limit             *int    `query:"limit"`
+	Sort              *string `query:"sort"`
 }
 
 func (p ListFuturesQuotesParams) WithTimestamp(c Comparator, q Nanos) *ListFuturesQuotesParams {
 	switch c {
-	case EQ:  p.Timestamp = &q
-	case LT:  p.TimestampLT = &q
-	case LTE: p.TimestampLTE = &q
-	case GT:  p.TimestampGT = &q
-	case GTE: p.TimestampGTE = &q
+	case EQ:
+		p.Timestamp = &q
+	case LT:
+		p.TimestampLT = &q
+	case LTE:
+		p.TimestampLTE = &q
+	case GT:
+		p.TimestampGT = &q
+	case GTE:
+		p.TimestampGTE = &q
 	}
 	return &p
 }
 
 func (p ListFuturesQuotesParams) WithSessionEndDate(c Comparator, q string) *ListFuturesQuotesParams {
 	switch c {
-	case EQ:  p.SessionEndDate = &q
-	case LT:  p.SessionEndDateLT = &q
-	case LTE: p.SessionEndDateLTE = &q
-	case GT:  p.SessionEndDateGT = &q
-	case GTE: p.SessionEndDateGTE = &q
+	case EQ:
+		p.SessionEndDate = &q
+	case LT:
+		p.SessionEndDateLT = &q
+	case LTE:
+		p.SessionEndDateLTE = &q
+	case GT:
+		p.SessionEndDateGT = &q
+	case GTE:
+		p.SessionEndDateGTE = &q
 	}
 	return &p
 }
@@ -275,15 +295,15 @@ type ListFuturesQuotesResponse struct {
 
 // FuturesQuote represents a quote for a futures contract.
 type FuturesQuote struct {
-	AskPrice     float64 `json:"ask_price,omitempty"`
-	AskSize      float64 `json:"ask_size,omitempty"`
-	AskTimestamp Nanos   `json:"ask_timestamp,omitempty"`
-	BidPrice     float64 `json:"bid_price,omitempty"`
-	BidSize      float64 `json:"bid_size,omitempty"`
-	BidTimestamp Nanos   `json:"bid_timestamp,omitempty"`
-	SessionEndDate string `json:"session_end_date,omitempty"`
-	Ticker       string `json:"ticker,omitempty"`
-	Timestamp    Nanos   `json:"timestamp,omitempty"`
+	AskPrice       float64 `json:"ask_price,omitempty"`
+	AskSize        float64 `json:"ask_size,omitempty"`
+	AskTimestamp   Nanos   `json:"ask_timestamp,omitempty"`
+	BidPrice       float64 `json:"bid_price,omitempty"`
+	BidSize        float64 `json:"bid_size,omitempty"`
+	BidTimestamp   Nanos   `json:"bid_timestamp,omitempty"`
+	SessionEndDate string  `json:"session_end_date,omitempty"`
+	Ticker         string  `json:"ticker,omitempty"`
+	Timestamp      Nanos   `json:"timestamp,omitempty"`
 }
 
 // ListFuturesSchedulesParams defines parameters for the ListFuturesSchedules endpoint.
@@ -302,39 +322,49 @@ type ListFuturesSchedulesResponse struct {
 
 // ListFuturesTradesParams defines parameters for the ListFuturesTrades endpoint.
 type ListFuturesTradesParams struct {
-	Ticker           string  `validate:"required" path:"ticker"`
-	Timestamp        *Nanos  `query:"timestamp"`
-	TimestampLT      *Nanos  `query:"timestamp.lt"`
-	TimestampLTE     *Nanos  `query:"timestamp.lte"`
-	TimestampGT      *Nanos  `query:"timestamp.gt"`
-	TimestampGTE     *Nanos  `query:"timestamp.gte"`
-	SessionEndDate   *string `query:"session_end_date"`
+	Ticker            string  `validate:"required" path:"ticker"`
+	Timestamp         *Nanos  `query:"timestamp"`
+	TimestampLT       *Nanos  `query:"timestamp.lt"`
+	TimestampLTE      *Nanos  `query:"timestamp.lte"`
+	TimestampGT       *Nanos  `query:"timestamp.gt"`
+	TimestampGTE      *Nanos  `query:"timestamp.gte"`
+	SessionEndDate    *string `query:"session_end_date"`
 	SessionEndDateLT  *string `query:"session_end_date.lt"`
 	SessionEndDateLTE *string `query:"session_end_date.lte"`
 	SessionEndDateGT  *string `query:"session_end_date.gt"`
 	SessionEndDateGTE *string `query:"session_end_date.gte"`
-	Limit            *int    `query:"limit"`
-	Sort             *string `query:"sort"`
+	Limit             *int    `query:"limit"`
+	Sort              *string `query:"sort"`
 }
 
 func (p ListFuturesTradesParams) WithTimestamp(c Comparator, q Nanos) *ListFuturesTradesParams {
 	switch c {
-	case EQ:  p.Timestamp = &q
-	case LT:  p.TimestampLT = &q
-	case LTE: p.TimestampLTE = &q
-	case GT:  p.TimestampGT = &q
-	case GTE: p.TimestampGTE = &q
+	case EQ:
+		p.Timestamp = &q
+	case LT:
+		p.TimestampLT = &q
+	case LTE:
+		p.TimestampLTE = &q
+	case GT:
+		p.TimestampGT = &q
+	case GTE:
+		p.TimestampGTE = &q
 	}
 	return &p
 }
 
 func (p ListFuturesTradesParams) WithSessionEndDate(c Comparator, q string) *ListFuturesTradesParams {
 	switch c {
-	case EQ:  p.SessionEndDate = &q
-	case LT:  p.SessionEndDateLT = &q
-	case LTE: p.SessionEndDateLTE = &q
-	case GT:  p.SessionEndDateGT = &q
-	case GTE: p.SessionEndDateGTE = &q
+	case EQ:
+		p.SessionEndDate = &q
+	case LT:
+		p.SessionEndDateLT = &q
+	case LTE:
+		p.SessionEndDateLTE = &q
+	case GT:
+		p.SessionEndDateGT = &q
+	case GTE:
+		p.SessionEndDateGTE = &q
 	}
 	return &p
 }
@@ -347,9 +377,9 @@ type ListFuturesTradesResponse struct {
 
 // FuturesTrade represents a trade for a futures contract.
 type FuturesTrade struct {
-	Price         float64 `json:"price,omitempty"`
-	SessionEndDate string `json:"session_end_date,omitempty"`
-	Size          float64 `json:"size,omitempty"`
-	Ticker        string `json:"ticker,omitempty"`
-	Timestamp     Nanos   `json:"timestamp,omitempty"`
+	Price          float64 `json:"price,omitempty"`
+	SessionEndDate string  `json:"session_end_date,omitempty"`
+	Size           float64 `json:"size,omitempty"`
+	Ticker         string  `json:"ticker,omitempty"`
+	Timestamp      Nanos   `json:"timestamp,omitempty"`
 }

--- a/rest/polygon.go
+++ b/rest/polygon.go
@@ -17,6 +17,7 @@ type Client struct {
 	SnapshotClient
 	IndicatorsClient
 	SummariesClient
+	FuturesClient
 	VX VXClient
 }
 
@@ -47,6 +48,7 @@ func newClient(apiKey string, hc *http.Client) *Client {
 		ReferenceClient:  ReferenceClient{Client: c},
 		TradesClient:     TradesClient{Client: c},
 		SnapshotClient:   SnapshotClient{Client: c},
+		FuturesClient:    FuturesClient{Client: c},
 		VX:               VXClient{Client: c},
 	}
 }

--- a/websocket/models/models.go
+++ b/websocket/models/models.go
@@ -403,3 +403,40 @@ type FairMarketValue struct {
 	// The Timestamp in nanoseconds.
 	Timestamp int64 `json:"t,omitempty"`
 }
+
+// FuturesTrade represents a futures trade event.
+type FuturesTrade struct {
+	EventType
+	Symbol    string  `json:"sym,omitempty"`
+	Price     float64 `json:"p,omitempty"`
+	Size      int64   `json:"s,omitempty"`
+	Timestamp int64   `json:"t,omitempty"`
+}
+
+// FuturesQuote represents a futures quote event.
+type FuturesQuote struct {
+	EventType
+	Symbol    string  `json:"sym,omitempty"`
+	BidPrice  float64 `json:"bp,omitempty"`
+	BidSize   int64   `json:"bs,omitempty"`
+	AskPrice  float64 `json:"ap,omitempty"`
+	AskSize   int64   `json:"as,omitempty"`
+	Timestamp int64   `json:"t,omitempty"`
+}
+
+// FuturesAggregate represents an aggregate event (e.g., second or minute) for a futures contract.
+type FuturesAggregate struct {
+	EventType         string  `json:"ev,omitempty"`
+	Symbol            string  `json:"sym,omitempty"`
+	Volume            float64 `json:"v,omitempty"`
+	AccumulatedVolume float64 `json:"av,omitempty"`
+	OfficialOpenPrice float64 `json:"op,omitempty"`
+	Open              float64 `json:"o,omitempty"`
+	Close             float64 `json:"c,omitempty"`
+	High              float64 `json:"h,omitempty"`
+	Low               float64 `json:"l,omitempty"`
+	AveragePrice      float64 `json:"a,omitempty"`
+	StartTimestamp    int64   `json:"s,omitempty"`
+	EndTimestamp      int64   `json:"e,omitempty"`
+	OTC               bool    `json:"otc,omitempty"`
+}


### PR DESCRIPTION
Added futures REST and WebSocket support (alpha). Includes new REST endpoints for futures data (e.g., aggregates, contracts, market statuses, etc) and WebSocket modelss.

REST examples:

```go
package main

import (
	"context"
	"log"

	polygon "github.com/polygon-io/client-go/rest"
	"github.com/polygon-io/client-go/rest/models"
)

func main() {

	c := polygon.New("YOUR_API_KEY")

	params := models.ListFuturesProductsParams{
	}

	iter := c.ListFuturesProducts(context.Background(), &params)

	for iter.Next() {
		log.Print(iter.Item())
	}
	if iter.Err() != nil {
		log.Fatal(iter.Err())
	}

}
```

I'll update the docs code examples with a PR to the docs repo.