### PR TITLE
fix(ws): reduce excessive websocket reconnects due to aggressive ping/pong timing

### DIFF
--- a/websocket/polygon.go
+++ b/websocket/polygon.go
@@ -19,9 +19,9 @@ import (
 
 const (
 	writeWait      = 5 * time.Second
-	pongWait       = 10 * time.Second
-	pingPeriod     = (pongWait * 9) / 10
-	maxMessageSize = 1000000 // 1MB
+	pongWait       = 30 * time.Second
+	pingPeriod     = pongWait - 5*time.Second // send ping 5 seconds before deadline
+	maxMessageSize = 1_000_000                // 1MB
 )
 
 // Client defines a client to the Polygon WebSocket API.
@@ -314,6 +314,9 @@ func (c *Client) read() error {
 					return fmt.Errorf("connection closed unexpectedly: %w", err)
 				}
 				return fmt.Errorf("failed to read message: %w", err)
+			}
+			if err := c.conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+				return fmt.Errorf("failed to set read deadline: %w", err)
 			}
 			c.rQueue <- msg
 		}


### PR DESCRIPTION
This PR addresses excessive websocket reconnects due to overly strict ping/pong timings causing false positives on connection drops. This also aligns with how the other clients are doing things re: timeouts.

### Changes made:
- Increased `pongWait` timeout from 10 seconds to 30 seconds.
- Clearly set `pingPeriod` to occur 5 seconds before `pongWait` timeout.
- Modified websocket read handling to reset the connection read deadline upon receiving any message, rather than only on ping/pong messages.

These changes ensure the websocket connection remains stable under normal network conditions and reduces unnecessary reconnects.