### PR TITLE
Update test.yml to remove 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x]
     name: go-test
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
We're at 1.25.x now. I wanted to start updating since 1.18 is blocking some dependabot stuff. My plan is to remove 1.18 for new and then test adding the newer version shortly here. I just wanted to break this up to unblock things for now.