### PR TITLE
[DEVREL-139] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @morningvera @mmoghaddam385 @jbonzo @justinpolygon @kschoche @HunterL @lukeoleson
+* @justinpolygon @suever @kschoche @lukeoleson @mmoghaddam385 @jbonzo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @justinpolygon @suever @kschoche @lukeoleson @mmoghaddam385 @jbonzo
+* @massive-com/client-library-reviewers 


### PR DESCRIPTION
Updates `.github/CODEOWNERS` to the standard DevRel team format:

```
* @justinpolygon @suever @kschoche @lukeoleson @mmoghaddam385 @jbonzo
```

Ref: DEVREL-139