### PR TITLE
[MASS-1218] Use GitHub App identity for OpenAPI sync commits

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -73,26 +73,25 @@ jobs:
             git diff --cached --stat | tail -25
           fi
 
-      - name: Import GPG signing key
-        if: steps.diff.outputs.changed == 'true'
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
       # A unique branch per run (date + run id) so every sync opens a brand-new
       # PR and never reuses/updates a previous one.
-      - name: Commit and push
+      - name: Create sync branch
         if: steps.diff.outputs.changed == 'true'
         run: |
-          git config user.name "justinpolygon"
-          git config user.email "123573436+justinpolygon@users.noreply.github.com"
           BRANCH="bot/openapi-sync-$(date -u +'%Y-%m-%d')-${GITHUB_RUN_ID}"
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
           git checkout -B "$BRANCH"
-          git commit -S -m "Sync client-go with OpenAPI spec"
-          git push origin "$BRANCH"
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        uses: iarekylew00t/verified-bot-commit@v2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          message: "Sync client-go with OpenAPI spec"
+          ref: ${{ env.BRANCH }}
+          files: |
+            rest/
+            scripts/
 
       - name: Open PR
         if: steps.diff.outputs.changed == 'true'

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -53,8 +53,7 @@ what's committed it:
 
 - mints a short-lived **GitHub App** token (the default `GITHUB_TOKEN` can't open
   PRs — org policy blocks it),
-- makes a **GPG-signed** commit as the bot identity `justinpolygon`
-  (`123573436+justinpolygon@users.noreply.github.com`),
+- commits as the GitHub App's bot identity,
 - pushes a **unique** branch `bot/openapi-sync-<date>-<run-id>` and opens a
   brand-new `[bot]`-prefixed PR (never reusing an existing one, so author ≠
   reviewer),
@@ -66,7 +65,6 @@ what's committed it:
 | --- | --- | --- |
 | Variable | `MASSIVE_CLIENT_LIBRARY_AUTOMATION_APP_ID` | GitHub App id (App must be installed on this repo) |
 | Secret | `MASSIVE_CLIENT_LIBRARY_AUTOMATION_APP_PRIVATE_KEY` | GitHub App private key |
-| Secret | `GPG_PRIVATE_KEY` | Signs the bot commit (shared with client-jvm / client-js) |
 | Secret | `SLACK_CLIENT_LIBRARY_WEBHOOK` | Slack notification (shared; optional — skipped if unset) |
 
 ## Per-file reference


### PR DESCRIPTION
The OpenAPI sync workflow was using justinpolygon's personal identity and a GPG key to sign commits. This switches to creating commits through the Git Data API using the GitHub App token instead. Commits created this way are automatically marked as verified by GitHub without needing a separate GPG key, and they're authored by the `massive-client-library-automation[bot]` app rather than a personal account.

The `GPG_PRIVATE_KEY` secret is no longer needed by this workflow.